### PR TITLE
Remove zenhub badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@
 [![Coverage Status](https://coveralls.io/repos/github/cloudigrade/cloudigrade/badge.svg?branch=coverage-configs)](https://coveralls.io/github/cloudigrade/cloudigrade?branch=coverage-configs)
 [![Updates](https://pyup.io/repos/github/cloudigrade/cloudigrade/shield.svg)](https://pyup.io/repos/github/cloudigrade/cloudigrade/)
 [![Python 3](https://pyup.io/repos/github/cloudigrade/cloudigrade/python-3-shield.svg)](https://pyup.io/repos/github/cloudigrade/cloudigrade/)
-[![Scrum Board](https://img.shields.io/badge/Shipping_faster_with-ZenHub-5e60ba.svg?style=flat)](https://app.zenhub.com/workspace/o/cloudigrade/cloudigrade/boards?repos=118967787)


### PR DESCRIPTION
This PR will remove the zenhub badge from the README file. 


Why?

Two issues, one is that zenhub isn't public and open to the world, you need to authenticate with a github account to view it, so it loses value to a passerby. 
Second is that it adds an extra space before the badge for some mysterious reason and mucks up the formatting.