### PR TITLE
Stricter coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,15 @@
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "75...95"
 
   status:
     project:
-      default: on
+      default:
+        target: "80%"
     patch:
-      default: on
+      default:
+        target: "80%"
     changes:
       default: off
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,10 @@ branch = True
 data_file = .coverage
 source = cloudigrade
 omit =
+    *config/settings/*
+    *config/urls.py
+    *config/wsgi.py
+    *manage.py
     *migrations*
     *static*
     *templates*


### PR DESCRIPTION
This excludes the config module along with manage.py from being picked up by coverage. This also adjusts codecov.io to fail commit status with below 80% coverage. After this PR is merged we can turn on the requirement for codecov status messages.