### PR TITLE
Add a web runner, plus other fantastic docker tweaks!

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     *config/settings/*
     *config/urls.py
     *config/wsgi.py
+    *config/gunicorn.py
     *manage.py
     *migrations*
     *static*

--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,6 @@ ENV/
 # mypy
 .mypy_cache/
 
-# sqlite
+# databases
 *.sqlite3
+/pg_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apk --no-cache --update add --virtual build-deps python3-dev gcc postgresql-
   && apk del build-deps \
   && rm -rf requirements
 
-USER cloudigrade
 COPY cloudigrade .
+RUN PYTHONPATH=. && python manage.py collectstatic --no-input --settings=config.settings.docker
 
-ENTRYPOINT ["python","manage.py"]
-CMD ["runserver","0.0.0.0:8000"]
+USER cloudigrade
+ENTRYPOINT ["gunicorn"]
+CMD ["-c","config/gunicorn.py","config.wsgi"]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 reinitdb: stop-compose remove-compose-db start-db run-docker-migrations
 
 remove-compose-db:
-	rm -rf /tmp/postgresql
+	rm -rf $(TOPDIR)/pg_data
 
 run-docker-migrations:
 	sleep 1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Doppler is another code name for cloudigrade.
 Or is cloudigrade a code name for Doppler?
 
 `cloudigrade == Doppler` for all intents and purposes. 😉
-   
+
 
 # Developing cloudigrade
 
@@ -46,6 +46,12 @@ Get into the cloudigrade project code:
     git clone git@github.com:cloudigrade/cloudigrade.git
     cd cloudigrade
 
+Need to run cloudigrade? Use docker-compose!
+
+    make start-compose
+
+This will also mount the `./cloudigrade` folder inside the container, so you can
+continue working on code and it will auto-reload in the container.
 
 ## AWS account setup
 

--- a/cloudigrade/config/gunicorn.py
+++ b/cloudigrade/config/gunicorn.py
@@ -1,0 +1,5 @@
+"""Gunicorn configuration file."""
+import multiprocessing
+
+bind = 'unix:/var/run/cloudigrade/gunicorn.sock'
+workers = multiprocessing.cpu_count() * 2 + 1

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -134,6 +134,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = str(ROOT_DIR.path('static'))
 
 
 # Django Rest Framework

--- a/cloudigrade/config/settings/docker.py
+++ b/cloudigrade/config/settings/docker.py
@@ -1,0 +1,10 @@
+from .base import *  # noqa
+
+
+DEBUG = env.bool('DJANGO_DEBUG', default=True)
+SECRET_KEY = env('DJANGO_SECRET_KEY', default='docker')
+ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', default=['*'])
+
+DATABASES = {
+    'default': env.db(default='postgres://postgres:postgres@db:5432/postgres')
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,19 +6,29 @@ services:
     ports:
       - "15432:5432"
     volumes:
-      - /tmp/postgresql:/var/lib/postgresql
-  migrate:
-    build: .
-    command: migrate
-    environment:
-      - DJANGO_SETTINGS_MODULE=config.settings.docker
-    depends_on:
-      - db
+      - ./pg_data:/var/lib/postgresql
   app:
     build: .
+    entrypoint: /opt/cloudigrade/entrypoint.sh
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.docker
-    ports:
-      - "8000:8000"
+    volumes:
+      - ./cloudigrade:/opt/cloudigrade
+      - ./docker/entrypoint.sh:/opt/cloudigrade/entrypoint.sh
+      - /tmp/cloudigrade/socket:/var/run/cloudigrade
+      - static:/opt/cloudigrade/static
     depends_on:
       - db
+  web:
+    image: nginx:alpine
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf
+      - /tmp/cloudigrade/socket:/var/run/cloudigrade
+      - static:/opt/cloudigrade/static
+    ports:
+      - "80:80"
+    depends_on:
+      - app
+
+volumes:
+  static:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while ! nc -w 1 -z db 5432;
+do
+    sleep 0.1;
+    echo "entrypoint.sh: Waiting on postgres."
+done;
+
+echo "entrypoint.sh: Postgres is alive, proceeding with migrations."
+./manage.py migrate;
+echo "entrypoint.sh: Migrations are done, starting gunicorn."
+gunicorn -c config/gunicorn.py --reload config.wsgi

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,46 @@
+worker_processes 1;
+
+user nobody nogroup;
+pid /tmp/nginx.pid;
+error_log /tmp/nginx.error.log;
+
+events {
+    worker_connections 1024;
+    accept_mutex off;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    access_log /tmp/nginx.access.log combined;
+    sendfile on;
+
+    upstream app_server {
+        server unix:/var/run/cloudigrade/gunicorn.sock fail_timeout=0;
+    }
+
+    server {
+        listen 80 default;
+        client_max_body_size 4G;
+        server_name _;
+
+        keepalive_timeout 5;
+
+        location /static {
+            autoindex on;
+            alias /opt/cloudigrade/static;
+        }
+
+        location / {
+            try_files $uri @proxy_to_app;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+
+            proxy_pass   http://app_server;
+        }
+    }
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ django-model-utils==3.1.1
 psycopg2cffi==2.7.7
 python-dateutil==2.6.1
 djangorestframework==3.7.7
+gunicorn==19.7.1


### PR DESCRIPTION
- Gunicorn has been implemented as the web runner for cloudigrade.
- Postgres data directory is no longer kept in /tmp, so you can actually expect it to survive reboots.
- Added nginx to the compose file, it will serve the gunicorn app and static files.
- Actually committed the docker.py config file.