### PR TITLE
Tweak tox and travis files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,17 @@ jobs:
   include:
     - stage: test
       python: 3.6
-      install: pip install tox-travis codecov
-      script: tox
+      install: pip install tox codecov
+      script: tox -epy36
       after_success: codecov
     - stage: test
+      python: 3.6
+      install: pip install tox
+      script: tox -eflake8
+    - stage: test
       python: pypy3
-      install: pip install tox-travis codecov
-      script: tox
-      after_success: codecov
+      install: pip install tox
+      script: tox -epypy3
     - stage: build container
       services: docker
       sudo: required

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py36, pypy3
+envlist = py36, pypy3, flake8
 skipsdist = True
 
 [flake8]
 ; D106 = Missing docstring in public nested class
 ; D212 = Multi-line docstring summary should start at the first line
 ignore = D106,D212
+max-complexity = 10
 exclude =
   **/__init__.py
   **/manage.py
@@ -18,8 +19,19 @@ deps =
   -rrequirements/test.txt
 setenv =
   DJANGO_SETTINGS_MODULE=config.settings.test
-  PYTHONPATH={toxinidir}/cluodigrade
+  PYTHONPATH={toxinidir}/cloudigrade
 commands =
-  flake8 --max-complexity 10 cloudigrade
   coverage run {toxinidir}/cloudigrade/manage.py test account analyzer util
   coverage report --show-missing
+
+[testenv:pypy3]
+commands =
+  python {toxinidir}/cloudigrade/manage.py test account analyzer util
+
+[testenv:flake8]
+deps =
+  flake8
+  flake8-docstrings
+  flake8-quotes
+commands =
+  flake8 cloudigrade


### PR DESCRIPTION
This updates the tox and travis files to have a separate env/build for flake8, while only py36 env will report coverage.