### PR TITLE
Modified EC2 snapshot API calls to not fail on undoc'd AWS validation

### DIFF
--- a/cloudigrade/util/aws.py
+++ b/cloudigrade/util/aws.py
@@ -285,17 +285,17 @@ def _verify_policy_action(session, action):
         elif action == 'ec2:DescribeSnapshotAttribute':
             ec2.describe_snapshot_attribute(
                 DryRun=True,
-                SnapshotId='string',
+                SnapshotId='snap-0f423c31dd96866b2',
                 Attribute='productCodes'
             )
         elif action == 'ec2:DescribeSnapshots':
             ec2.describe_snapshots(DryRun=True)
         elif action == 'ec2:ModifySnapshotAttribute':
             ec2.modify_snapshot_attribute(
-                SnapshotId='string',
+                SnapshotId='snap-0f423c31dd96866b2',
                 DryRun=True,
-                Attribute='productCodes',
-                GroupNames=['string', ]
+                Attribute='createVolumePermission',
+                OperationType='add',
             )
         elif action == 'ec2:ModifyImageAttribute':
             ec2.modify_image_attribute(

--- a/cloudigrade/util/aws.py
+++ b/cloudigrade/util/aws.py
@@ -31,6 +31,13 @@ cloudigrade_policy = {
     ]
 }
 
+# AWS has undocumented validation on the SnapshotId field in
+# snapshot related EC2 API calls.
+# We are uncertain what the pattern is. Manual testing revealed
+# that some codes pass and some fail, so for the time being
+# the value is hard-coded.
+SNAPSHOT_ID = 'snap-0f423c31dd96866b2'
+
 
 class InstanceState(enum.Enum):
     """
@@ -285,14 +292,14 @@ def _verify_policy_action(session, action):
         elif action == 'ec2:DescribeSnapshotAttribute':
             ec2.describe_snapshot_attribute(
                 DryRun=True,
-                SnapshotId='snap-0f423c31dd96866b2',
+                SnapshotId=SNAPSHOT_ID,
                 Attribute='productCodes'
             )
         elif action == 'ec2:DescribeSnapshots':
             ec2.describe_snapshots(DryRun=True)
         elif action == 'ec2:ModifySnapshotAttribute':
             ec2.modify_snapshot_attribute(
-                SnapshotId='snap-0f423c31dd96866b2',
+                SnapshotId=SNAPSHOT_ID,
                 DryRun=True,
                 Attribute='createVolumePermission',
                 OperationType='add',

--- a/cloudigrade/util/tests/test_aws.py
+++ b/cloudigrade/util/tests/test_aws.py
@@ -239,6 +239,8 @@ class UtilAwsTest(TestCase):
             mock_modify_image_attribute.side_effect = ClientError(
                 mock_dry_run_exception, 'ModifyImageAttribute')
 
+            snapshot_id = 'snap-0f423c31dd96866b2'
+
             actual_verified = aws.verify_account_access(
                 aws.get_session(mock_arn))
 
@@ -246,15 +248,15 @@ class UtilAwsTest(TestCase):
             mock_describe_instances.assert_called_with(DryRun=True)
             mock_describe_snapshot_attribute.assert_called_with(
                 DryRun=True,
-                SnapshotId='string',
+                SnapshotId=snapshot_id,
                 Attribute='productCodes'
             )
             mock_describe_snapshots.assert_called_with(DryRun=True)
             mock_modify_snapshot_attribute.assert_called_with(
-                SnapshotId='string',
+                SnapshotId=snapshot_id,
                 DryRun=True,
-                Attribute='productCodes',
-                GroupNames=['string', ]
+                Attribute='createVolumePermission',
+                OperationType='add'
             )
             mock_modify_image_attribute.assert_called_with(
                 Attribute='description',
@@ -323,6 +325,8 @@ class UtilAwsTest(TestCase):
             mock_modify_image_attribute.side_effect = ClientError(
                 mock_unauthorized_exception, 'ModifyImageAttribute')
 
+            snapshot_id = 'snap-0f423c31dd96866b2'
+
             session = aws.get_session(mock_arn)
             actual_verified = aws.verify_account_access(session)
 
@@ -344,15 +348,15 @@ class UtilAwsTest(TestCase):
             mock_describe_instances.assert_called_with(DryRun=True)
             mock_describe_snapshot_attribute.assert_called_with(
                 DryRun=True,
-                SnapshotId='string',
+                SnapshotId=snapshot_id,
                 Attribute='productCodes'
             )
             mock_describe_snapshots.assert_called_with(DryRun=True)
             mock_modify_snapshot_attribute.assert_called_with(
-                SnapshotId='string',
+                SnapshotId=snapshot_id,
                 DryRun=True,
-                Attribute='productCodes',
-                GroupNames=['string', ]
+                Attribute='createVolumePermission',
+                OperationType='add',
             )
             mock_modify_image_attribute.assert_called_with(
                 Attribute='description',

--- a/cloudigrade/util/tests/test_aws.py
+++ b/cloudigrade/util/tests/test_aws.py
@@ -239,8 +239,6 @@ class UtilAwsTest(TestCase):
             mock_modify_image_attribute.side_effect = ClientError(
                 mock_dry_run_exception, 'ModifyImageAttribute')
 
-            snapshot_id = 'snap-0f423c31dd96866b2'
-
             actual_verified = aws.verify_account_access(
                 aws.get_session(mock_arn))
 
@@ -248,12 +246,12 @@ class UtilAwsTest(TestCase):
             mock_describe_instances.assert_called_with(DryRun=True)
             mock_describe_snapshot_attribute.assert_called_with(
                 DryRun=True,
-                SnapshotId=snapshot_id,
+                SnapshotId=aws.SNAPSHOT_ID,
                 Attribute='productCodes'
             )
             mock_describe_snapshots.assert_called_with(DryRun=True)
             mock_modify_snapshot_attribute.assert_called_with(
-                SnapshotId=snapshot_id,
+                SnapshotId=aws.SNAPSHOT_ID,
                 DryRun=True,
                 Attribute='createVolumePermission',
                 OperationType='add'
@@ -325,8 +323,6 @@ class UtilAwsTest(TestCase):
             mock_modify_image_attribute.side_effect = ClientError(
                 mock_unauthorized_exception, 'ModifyImageAttribute')
 
-            snapshot_id = 'snap-0f423c31dd96866b2'
-
             session = aws.get_session(mock_arn)
             actual_verified = aws.verify_account_access(session)
 
@@ -348,12 +344,12 @@ class UtilAwsTest(TestCase):
             mock_describe_instances.assert_called_with(DryRun=True)
             mock_describe_snapshot_attribute.assert_called_with(
                 DryRun=True,
-                SnapshotId=snapshot_id,
+                SnapshotId=aws.SNAPSHOT_ID,
                 Attribute='productCodes'
             )
             mock_describe_snapshots.assert_called_with(DryRun=True)
             mock_modify_snapshot_attribute.assert_called_with(
-                SnapshotId=snapshot_id,
+                SnapshotId=aws.SNAPSHOT_ID,
                 DryRun=True,
                 Attribute='createVolumePermission',
                 OperationType='add',


### PR DESCRIPTION
This will get us running again. 