### PR TITLE
Tweak our docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ RUN scl enable rh-postgresql96 rh-python36 \
     && rm -rf requirements
 
 COPY cloudigrade .
-RUN scl enable rh-postgresql96 rh-python36 \
-    'python manage.py collectstatic --no-input --settings=config.settings.docker'
-
 USER cloudigrade
 ENTRYPOINT ["scl", "enable", "rh-postgresql96", "rh-python36", "--", "gunicorn"]
 CMD ["-c","config/gunicorn.py","config.wsgi"]

--- a/cloudigrade/config/settings/docker.py
+++ b/cloudigrade/config/settings/docker.py
@@ -11,3 +11,5 @@ DATABASES = {
 # Message and Task Queues
 
 RABBITMQ_URL = 'amqp://guest:guest@queue:5672/%2F'
+
+STATIC_ROOT = '/srv/cloudigrade/static/'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./pg_data:/var/lib/postgresql
   app:
     build: .
-    entrypoint: /opt/cloudigrade/entrypoint.sh
+    entrypoint: /opt/entrypoint.sh
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.docker
       - AWS_ACCESS_KEY_ID
@@ -17,9 +17,9 @@ services:
       - AWS_DEFAULT_REGION
     volumes:
       - ./cloudigrade:/opt/cloudigrade:Z
-      - ./docker/entrypoint.sh:/opt/cloudigrade/entrypoint.sh:Z
+      - ./docker/entrypoint.sh:/opt/entrypoint.sh:Z
       - /tmp/cloudigrade/socket:/var/run/cloudigrade:Z
-      - static:/opt/cloudigrade/static
+      - /tmp/cloudigrade/static:/srv/cloudigrade/static:Z
     depends_on:
       - db
   web:
@@ -27,9 +27,9 @@ services:
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:Z
       - /tmp/cloudigrade/socket:/var/run/cloudigrade:Z
-      - static:/opt/cloudigrade/static
+      - /tmp/cloudigrade/static:/srv/cloudigrade/static:Z
     ports:
-      - "8000:80"
+      - "8080:8080"
     depends_on:
       - app
   queue:
@@ -41,5 +41,3 @@ services:
       - RABBITMQ_DISK_FREE_LIMIT={mem_relative, 1.5}
     volumes:
       - ./rabbitmq:/var/lib/rabbitmq
-volumes:
-  static:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+set -e
+
+cd /opt/cloudigrade
+
+echo "entrypoint.sh: Collecting static files"
+scl enable rh-postgresql96 rh-python36 'python manage.py collectstatic --no-input --settings=config.settings.docker'
 
 while ! nc -w 1 --send-only < /dev/null db 5432;
 do

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,5 @@
 worker_processes 1;
 
-user nobody nogroup;
 pid /tmp/nginx.pid;
 error_log /tmp/nginx.error.log;
 
@@ -20,7 +19,7 @@ http {
     }
 
     server {
-        listen 80 default;
+        listen 8080 default;
         client_max_body_size 4G;
         server_name _;
 
@@ -28,7 +27,7 @@ http {
 
         location /static {
             autoindex on;
-            alias /opt/cloudigrade/static;
+            alias /srv/cloudigrade/static;
         }
 
         location / {


### PR DESCRIPTION
Tweaked several things in our docker config while making changes for #149 
* Remove user from nginx.conf
* Set nginx port to 8080
* **Update compose to listen and serve cloudigrade on 8080**
* Update compose to no longer use a named volume for static file
* Update compose to no longer mount the entrypoint.sh in the cloudigrade directory
* Update entrypoint script to collect static files
* Update dockerfile to no longer package staticfiles in the container
* Update nginx/compose/cloudigrade docker settings file indicating new static file path