### PR TITLE
scheduled task to conditionally scale up the houndigrade cluster

### DIFF
--- a/cloudigrade/account/tasks.py
+++ b/cloudigrade/account/tasks.py
@@ -85,4 +85,4 @@ def enqueue_ready_volume(ami_id, volume_id, region):
     aws.check_volume_state(volume)
     messages = [{'ami_id': ami_id, 'volume_id': volume_id}]
 
-    add_messages_to_queue('ready_volumes', messages, 'ami_id')
+    add_messages_to_queue('ready_volumes', messages)

--- a/cloudigrade/account/tests/test_tasks.py
+++ b/cloudigrade/account/tests/test_tasks.py
@@ -212,7 +212,7 @@ class AccountCeleryTaskTest(TestCase):
 
         enqueue_ready_volume(ami_id, volume_id, region)
 
-        mock_queue.assert_called_with('ready_volumes', messages, 'ami_id')
+        mock_queue.assert_called_with('ready_volumes', messages)
 
     @patch('account.tasks.aws')
     def test_enqueue_ready_volume_error(self, mock_aws):

--- a/cloudigrade/account/tests/test_tasks.py
+++ b/cloudigrade/account/tests/test_tasks.py
@@ -272,6 +272,10 @@ class AccountCeleryTaskTest(TestCase):
         mock_aws.is_scaled_down.assert_called_once_with(
             settings.HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME
         )
+        mock_read_messages_from_queue.assert_called_once_with(
+            'ready_volumes',
+            settings.HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE
+        )
         mock_aws.scale_up.assert_called_once_with(
             settings.HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME
         )
@@ -323,7 +327,10 @@ class AccountCeleryTaskTest(TestCase):
             settings.HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME
         )
         mock_aws.scale_up.assert_not_called()
-        mock_read_messages_from_queue.assert_called_once()
+        mock_read_messages_from_queue.assert_called_once_with(
+            'ready_volumes',
+            settings.HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE
+        )
         mock_run_inspection_cluster.delay.assert_not_called()
         mock_add_messages_to_queue.assert_not_called()
 

--- a/cloudigrade/account/tests/test_tasks.py
+++ b/cloudigrade/account/tests/test_tasks.py
@@ -264,7 +264,7 @@ class AccountCeleryTaskTest(TestCase):
     ):
         """Assert successful scaling with empty cluster and queued messages."""
         messages = [Mock()]
-        mock_aws.is_scaled_down.return_value = True
+        mock_aws.is_scaled_down.return_value = True, dict()
         mock_read_messages_from_queue.return_value = messages
 
         tasks.scale_up_inspection_cluster()
@@ -294,7 +294,7 @@ class AccountCeleryTaskTest(TestCase):
             mock_add_messages_to_queue
     ):
         """Assert scale up aborts when not scaled down."""
-        mock_aws.is_scaled_down.return_value = False
+        mock_aws.is_scaled_down.return_value = False, {'Instances': [Mock()]}
 
         tasks.scale_up_inspection_cluster()
 
@@ -318,7 +318,7 @@ class AccountCeleryTaskTest(TestCase):
             mock_add_messages_to_queue
     ):
         """Assert scale up aborts when not scaled down."""
-        mock_aws.is_scaled_down.return_value = True
+        mock_aws.is_scaled_down.return_value = True, dict()
         mock_read_messages_from_queue.return_value = []
 
         tasks.scale_up_inspection_cluster()
@@ -347,7 +347,7 @@ class AccountCeleryTaskTest(TestCase):
     ):
         """Assert messages requeue when scale_up encounters AWS exception."""
         messages = [Mock()]
-        mock_aws.is_scaled_down.return_value = True
+        mock_aws.is_scaled_down.return_value = True, dict()
         mock_read_messages_from_queue.return_value = messages
         mock_aws.scale_up.side_effect = ClientError({}, Mock())
 

--- a/cloudigrade/account/tests/test_util.py
+++ b/cloudigrade/account/tests/test_util.py
@@ -1,7 +1,7 @@
 """Collection of tests for utils in the account app."""
 import random
 from queue import Empty
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
@@ -93,7 +93,6 @@ class AccountUtilTest(TestCase):
         messages = util.generate_aws_ami_messages(instances_data, ami_list)
         mock_routing_key = queue_name
         mock_body = messages[0]
-        result_key = 'image_id'
 
         mock_exchange = mock_kombu.Exchange.return_value
         mock_queue = mock_kombu.Queue.return_value
@@ -102,7 +101,7 @@ class AccountUtilTest(TestCase):
         mock_producer = mock_with_conn.Producer.return_value
         mock_pub = mock_producer.publish
 
-        util.add_messages_to_queue(queue_name, messages, result_key)
+        util.add_messages_to_queue(queue_name, messages)
 
         mock_pub.assert_called_with(
             mock_body,

--- a/cloudigrade/account/tests/test_util.py
+++ b/cloudigrade/account/tests/test_util.py
@@ -128,8 +128,8 @@ class AccountUtilTest(TestCase):
         expected_results = [mock_messages[0].payload, mock_messages[1].payload]
         actual_results = util.read_messages_from_queue(queue_name, 5)
         self.assertEqual(actual_results, expected_results)
-        mock_messages[0].ack.assert_called_once()
-        mock_messages[1].ack.assert_called_once()
+        mock_messages[0].ack.assert_called_once_with()
+        mock_messages[1].ack.assert_called_once_with()
 
     @patch('account.util.kombu')
     def test_read_messages_from_queue_once(self, mock_kombu):
@@ -139,5 +139,5 @@ class AccountUtilTest(TestCase):
         expected_results = [mock_messages[0].payload]
         actual_results = util.read_messages_from_queue(queue_name)
         self.assertEqual(actual_results, expected_results)
-        mock_messages[0].ack.assert_called_once()
+        mock_messages[0].ack.assert_called_once_with()
         mock_messages[1].ack.assert_not_called()

--- a/cloudigrade/account/tests/test_util.py
+++ b/cloudigrade/account/tests/test_util.py
@@ -141,3 +141,14 @@ class AccountUtilTest(TestCase):
         self.assertEqual(actual_results, expected_results)
         mock_messages[0].ack.assert_called_once_with()
         mock_messages[1].ack.assert_not_called()
+
+    @patch('account.util.kombu')
+    def test_read_messages_from_queue_stops_at_limit(self, mock_kombu):
+        """Test that messages up to the batch size are read from the queue."""
+        mock_messages = self.prepare_mock_kombu_for_consuming(mock_kombu)
+        queue_name = 'Test Queue'
+        expected_results = [mock_messages[0].payload]
+        actual_results = util.read_messages_from_queue(queue_name, 1)
+        self.assertEqual(actual_results, expected_results)
+        mock_messages[0].ack.assert_called_once_with()
+        mock_messages[1].ack.assert_not_called()

--- a/cloudigrade/account/util.py
+++ b/cloudigrade/account/util.py
@@ -1,7 +1,6 @@
 """Various utility functions for the account app."""
-from queue import Empty
-
 import collections
+from queue import Empty
 
 import kombu
 from django.conf import settings
@@ -144,7 +143,7 @@ def _create_exchange_and_queue(queue_name):
     return exchange, message_queue
 
 
-def add_messages_to_queue(queue_name, messages, result_key):
+def add_messages_to_queue(queue_name, messages):
     """
     Send messages to a message queue.
 
@@ -152,8 +151,6 @@ def add_messages_to_queue(queue_name, messages, result_key):
         queue_name (str): The queue to add messages to
         messages (list[dict]): A list of message dictionaries. The message
             dicts will be serialized as JSON strings.
-        result_key (str): What to key the result dict on. This must be
-            a key in the message itself.
 
     Returns:
         dict: A mapping of machine image ID to result boolean value

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -44,6 +44,7 @@ DJANGO_APPS = [
 
 # Any pip installed apps will go here
 THIRD_PARTY_APPS = [
+    'django_celery_beat',
     'rest_framework',
     'rest_framework.authtoken',
 ]
@@ -190,3 +191,4 @@ CELERY_TASK_ROUTES = {
     'account.tasks.create_volume': {'queue': 'create_volume'},
     'account.tasks.enqueue_ready_volume': {'queue': 'enqueue_ready_volumes'},
 }
+CELERYBEAT_SCHEDULE = {}

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -201,8 +201,8 @@ CELERY_TASK_ROUTES = {
     'account.tasks.enqueue_ready_volume': {'queue': 'enqueue_ready_volumes'},
 }
 CELERYBEAT_SCHEDULE = {
-    'scale_up_inspection_cluster_every_5_min': {
+    'scale_up_inspection_cluster_every_60_min': {
         'task': 'account.tasks.scale_up_inspection_cluster',
-        'schedule': 60 * 5,  # seconds
+        'schedule': env.int('SCALE_UP_INSPECTION_CLUSTER_SCHEDULE', default=60 * 60),  # seconds
     },
 }

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -38,7 +38,7 @@ HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME = env(
 )
 HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE = env.int(
     'HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE',
-    default=5
+    default=32
 )
 
 # Default apps go here

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -30,7 +30,16 @@ ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', default=['*'])
 S3_DEFAULT_REGION = env('S3_DEFAULT_REGION', default='us-east-1')
 SQS_DEFAULT_REGION = env('SQS_DEFAULT_REGION', default='us-east-1')
 HOUNDIGRADE_AWS_AVAILABILITY_ZONE = env('HOUNDIGRADE_AWS_AVAILABILITY_ZONE',
-                                        default='us-east-1a')
+                                        default='us-east-1b')
+HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME = env(
+    'HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME',
+    default='EC2ContainerService-inspectigrade-test-bws-us-east-1b-'
+            'EcsInstanceAsg-JG9NX9WHX6NU'
+)
+HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE = env.int(
+    'HOUNDIGRADE_AWS_VOLUME_BATCH_SIZE',
+    default=5
+)
 
 # Default apps go here
 DJANGO_APPS = [
@@ -191,4 +200,9 @@ CELERY_TASK_ROUTES = {
     'account.tasks.create_volume': {'queue': 'create_volume'},
     'account.tasks.enqueue_ready_volume': {'queue': 'enqueue_ready_volumes'},
 }
-CELERYBEAT_SCHEDULE = {}
+CELERYBEAT_SCHEDULE = {
+    'scale_up_inspection_cluster_every_5_min': {
+        'task': 'account.tasks.scale_up_inspection_cluster',
+        'schedule': 60 * 5,  # seconds
+    },
+}

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -200,7 +200,7 @@ CELERY_TASK_ROUTES = {
     'account.tasks.create_volume': {'queue': 'create_volume'},
     'account.tasks.enqueue_ready_volume': {'queue': 'enqueue_ready_volumes'},
 }
-CELERYBEAT_SCHEDULE = {
+CELERY_BEAT_SCHEDULE = {
     'scale_up_inspection_cluster_every_60_min': {
         'task': 'account.tasks.scale_up_inspection_cluster',
         'schedule': env.int('SCALE_UP_INSPECTION_CLUSTER_SCHEDULE', default=60 * 60),  # seconds

--- a/cloudigrade/util/aws/__init__.py
+++ b/cloudigrade/util/aws/__init__.py
@@ -1,5 +1,7 @@
 """Helper utility package to wrap up common AWS operations."""
 from util.aws.arn import AwsArn
+from util.aws.autoscaling import (describe_auto_scaling_group,
+                                  is_scaled_down, scale_up)
 from util.aws.ec2 import (InstanceState, add_snapshot_ownership,
                           check_volume_state, copy_snapshot, create_volume,
                           get_ami,

--- a/cloudigrade/util/aws/autoscaling.py
+++ b/cloudigrade/util/aws/autoscaling.py
@@ -33,14 +33,17 @@ def is_scaled_down(name):
         name: Auto Scaling group name
 
     Returns:
-        bool: True if group indicates zero size and zero instances
+        tuple(bool, dict): the bool is True if group indicates zero size and
+            zero instances, and the dict has the auto scaling group details
+            that were described to make that determination.
 
     """
     auto_scaling_group = describe_auto_scaling_group(name)
-    return auto_scaling_group['MinSize'] == 0 and \
+    scaled_down = auto_scaling_group['MinSize'] == 0 and \
         auto_scaling_group['MaxSize'] == 0 and \
         auto_scaling_group['DesiredCapacity'] == 0 and \
         len(auto_scaling_group['Instances']) == 0
+    return scaled_down, auto_scaling_group
 
 
 def set_scale(name, min_size, max_size, desired_capacity):

--- a/cloudigrade/util/aws/autoscaling.py
+++ b/cloudigrade/util/aws/autoscaling.py
@@ -1,0 +1,81 @@
+"""Helper utility module to wrap up common AWS AutoScaling operations."""
+import boto3
+
+from util.exceptions import AwsAutoScalingGroupNotFound
+
+
+def describe_auto_scaling_group(name):
+    """
+    Describe the named Auto Scaling group.
+
+    Args:
+        name (str): Auto Scaling group name
+
+    Returns:
+        dict: Details describing the Auto Scaling group
+
+    """
+    autoscaling = boto3.client('autoscaling')
+    groups = autoscaling.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[name],
+        MaxRecords=1
+    )['AutoScalingGroups']
+    if len(groups) == 0:
+        raise AwsAutoScalingGroupNotFound(name)
+    return groups[0]
+
+
+def is_scaled_down(name):
+    """
+    Check if the Auto Scaling group is spun down with zero instances.
+
+    Args:
+        name: Auto Scaling group name
+
+    Returns:
+        bool: True if group indicates zero size and zero instances
+
+    """
+    auto_scaling_group = describe_auto_scaling_group(name)
+    return auto_scaling_group['MinSize'] == 0 and \
+        auto_scaling_group['MaxSize'] == 0 and \
+        auto_scaling_group['DesiredCapacity'] == 0 and \
+        len(auto_scaling_group['Instances']) == 0
+
+
+def set_scale(name, min_size, max_size, desired_capacity):
+    """
+    Set the Auto Scaling group to have exactly `count` instances.
+
+    Args:
+        name: Auto Scaling group name
+        min_size (int): group min size
+        max_size (int): group max size
+        desired_capacity (int): group desired capacity
+
+    Returns:
+        dict: AWS response metadata
+
+    """
+    autoscaling = boto3.client('autoscaling')
+    response = autoscaling.update_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=min_size,
+        MaxSize=max_size,
+        DesiredCapacity=desired_capacity,
+    )
+    return response
+
+
+def scale_up(name):
+    """
+    Set the Auto Scaling group to have exactly 1 instance.
+
+    Args:
+        name: Auto Scaling group name
+
+    Returns:
+        dict: AWS response metadata
+
+    """
+    return set_scale(name, 1, 1, 1)

--- a/cloudigrade/util/exceptions.py
+++ b/cloudigrade/util/exceptions.py
@@ -41,3 +41,11 @@ class AwsVolumeNotReadyError(NotReadyException):
 
 class AwsVolumeError(Exception):
     """The requested volume is not in an acceptable state."""
+
+
+class AwsAutoScalingGroupNotFound(Exception):
+    """The requested AutoScaling group was not found."""
+
+
+class AwsNonZeroAutoScalingGroupSize(Exception):
+    """Raise when AWS auto scaling group has nonzero size."""

--- a/cloudigrade/util/tests/test_aws_autoscaling.py
+++ b/cloudigrade/util/tests/test_aws_autoscaling.py
@@ -50,7 +50,8 @@ class UtilAwsAutoScalingTest(TestCase):
             'Instances': [],
         }
         name = str(uuid.uuid4())
-        self.assertTrue(autoscaling.is_scaled_down(name))
+        scaled, _ = autoscaling.is_scaled_down(name)
+        self.assertTrue(scaled)
 
     @patch('util.aws.autoscaling.describe_auto_scaling_group')
     def test_is_scaled_down_false_when_scaling_up(self, mock_describe):
@@ -62,7 +63,8 @@ class UtilAwsAutoScalingTest(TestCase):
             'Instances': [],
         }
         name = str(uuid.uuid4())
-        self.assertFalse(autoscaling.is_scaled_down(name))
+        scaled, _ = autoscaling.is_scaled_down(name)
+        self.assertFalse(scaled)
 
     @patch('util.aws.autoscaling.describe_auto_scaling_group')
     def test_is_scaled_down_false_when_scaled_up(self, mock_describe):
@@ -74,7 +76,8 @@ class UtilAwsAutoScalingTest(TestCase):
             'Instances': [Mock()],
         }
         name = str(uuid.uuid4())
-        self.assertFalse(autoscaling.is_scaled_down(name))
+        scaled, _ = autoscaling.is_scaled_down(name)
+        self.assertFalse(scaled)
 
     @patch('util.aws.autoscaling.describe_auto_scaling_group')
     def test_is_scaled_down_false_when_scaling_down(self, mock_describe):
@@ -86,7 +89,8 @@ class UtilAwsAutoScalingTest(TestCase):
             'Instances': [Mock()],
         }
         name = str(uuid.uuid4())
-        self.assertFalse(autoscaling.is_scaled_down(name))
+        scaled, _ = autoscaling.is_scaled_down(name)
+        self.assertFalse(scaled)
 
     @patch('util.aws.autoscaling.boto3')
     def test_set_scale(self, mock_boto3):

--- a/cloudigrade/util/tests/test_aws_autoscaling.py
+++ b/cloudigrade/util/tests/test_aws_autoscaling.py
@@ -1,0 +1,121 @@
+"""Collection of tests for ``util.aws.autoscaling`` module."""
+import uuid
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from util.aws import autoscaling
+from util.exceptions import AwsAutoScalingGroupNotFound
+
+
+class UtilAwsAutoScalingTest(TestCase):
+    """AWS Auto Scaling utility functions test case."""
+
+    @patch('util.aws.autoscaling.boto3')
+    def test_describe_auto_scaling_group(self, mock_boto3):
+        """Assert successful fetch of auto scaling group description."""
+        mock_group = Mock()
+        groups = {
+            'AutoScalingGroups': [mock_group]
+        }
+        client = mock_boto3.client.return_value
+        client.describe_auto_scaling_groups.return_value = groups
+
+        name = str(uuid.uuid4())
+        described_group = autoscaling.describe_auto_scaling_group(name)
+        self.assertEqual(described_group, mock_group)
+        mock_boto3.client.assert_called_once_with('autoscaling')
+
+    @patch('util.aws.autoscaling.boto3')
+    def test_describe_auto_scaling_group_not_found(self, mock_boto3):
+        """Assert getting group raises exception when not found."""
+        groups = {
+            'AutoScalingGroups': []
+        }
+        client = mock_boto3.client.return_value
+        client.describe_auto_scaling_groups.return_value = groups
+
+        name = str(uuid.uuid4())
+        with self.assertRaises(AwsAutoScalingGroupNotFound):
+            autoscaling.describe_auto_scaling_group(name)
+        mock_boto3.client.assert_called_once_with('autoscaling')
+
+    @patch('util.aws.autoscaling.describe_auto_scaling_group')
+    def test_is_scaled_down(self, mock_describe):
+        """Assert is_scaled_down is True when there are no instances."""
+        mock_describe.return_value = {
+            'MinSize': 0,
+            'MaxSize': 0,
+            'DesiredCapacity': 0,
+            'Instances': [],
+        }
+        name = str(uuid.uuid4())
+        self.assertTrue(autoscaling.is_scaled_down(name))
+
+    @patch('util.aws.autoscaling.describe_auto_scaling_group')
+    def test_is_scaled_down_false_when_scaling_up(self, mock_describe):
+        """Assert is_scaled_down is False when the cluster is scaling up."""
+        mock_describe.return_value = {
+            'MinSize': 1,
+            'MaxSize': 1,
+            'DesiredCapacity': 1,
+            'Instances': [],
+        }
+        name = str(uuid.uuid4())
+        self.assertFalse(autoscaling.is_scaled_down(name))
+
+    @patch('util.aws.autoscaling.describe_auto_scaling_group')
+    def test_is_scaled_down_false_when_scaled_up(self, mock_describe):
+        """Assert is_scaled_down is False when the cluster is scaled up."""
+        mock_describe.return_value = {
+            'MinSize': 1,
+            'MaxSize': 1,
+            'DesiredCapacity': 1,
+            'Instances': [Mock()],
+        }
+        name = str(uuid.uuid4())
+        self.assertFalse(autoscaling.is_scaled_down(name))
+
+    @patch('util.aws.autoscaling.describe_auto_scaling_group')
+    def test_is_scaled_down_false_when_scaling_down(self, mock_describe):
+        """Assert is_scaled_down is False when the cluster is scaling down."""
+        mock_describe.return_value = {
+            'MinSize': 0,
+            'MaxSize': 0,
+            'DesiredCapacity': 0,
+            'Instances': [Mock()],
+        }
+        name = str(uuid.uuid4())
+        self.assertFalse(autoscaling.is_scaled_down(name))
+
+    @patch('util.aws.autoscaling.boto3')
+    def test_set_scale(self, mock_boto3):
+        """Assert set_scale calls boto3 appropriately."""
+        client = mock_boto3.client.return_value
+        expected_response = client.update_auto_scaling_group.return_value
+
+        name = str(uuid.uuid4())
+        min_size = 1
+        desired_capacity = 2
+        max_size = 3
+
+        actual_response = autoscaling.set_scale(
+            name, min_size, max_size, desired_capacity
+        )
+
+        self.assertEqual(actual_response, expected_response)
+        mock_boto3.client.assert_called_once_with('autoscaling')
+        client.update_auto_scaling_group.assert_called_once_with(
+            AutoScalingGroupName=name,
+            MinSize=min_size,
+            MaxSize=max_size,
+            DesiredCapacity=desired_capacity
+        )
+
+    @patch('util.aws.autoscaling.set_scale')
+    def test_scale_up(self, mock_set_scale):
+        """Assert scale_up sets the scale to exactly 1."""
+        name = str(uuid.uuid4())
+        actual_response = autoscaling.scale_up(name)
+        self.assertEqual(actual_response, mock_set_scale.return_value)
+        mock_set_scale.assert_called_once_with(name, 1, 1, 1)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ djangorestframework==3.8.2
 gunicorn==19.7.1
 django-polymorphic==2.0.2
 django-rest-polymorphic==0.1.5
+django-celery-beat==1.1.1


### PR DESCRIPTION
https://github.com/cloudigrade/cloudigrade/issues/176

This PR adds our first support for scheduled Celery tasks using beat. As described in https://github.com/cloudigrade/cloudigrade/issues/176, this task checks the current cluster auto scaling size, checks the message queue for volume IDs, scales up to 1, and runs a (currently stubbed-out) async task that will be responsible for actually "running" houndigrade in the cluster.

Note: this PR builds upon the `organize-aws-helpers` branch and needs to merge _after_ #224 merges.

Demo: coming soon!