### PR TITLE
247 Fix `aws.add_snapshot_ownership`

### DIFF
--- a/cloudigrade/account/tasks.py
+++ b/cloudigrade/account/tasks.py
@@ -42,11 +42,7 @@ def copy_ami_snapshot(arn, ami_id, source_region):
         image.save()
         raise AwsSnapshotEncryptedError
 
-    aws.add_snapshot_ownership(
-        session,
-        snapshot,
-        source_region
-    )
+    aws.add_snapshot_ownership(snapshot)
 
     new_snapshot_id = aws.copy_snapshot(snapshot_id, source_region)
     create_volume.delay(ami_id, new_snapshot_id)

--- a/cloudigrade/account/tests/test_tasks.py
+++ b/cloudigrade/account/tests/test_tasks.py
@@ -55,11 +55,7 @@ class AccountCeleryTaskTest(TestCase):
             mock_region
         )
         mock_aws.get_ami_snapshot_id.assert_called_with(mock_image)
-        mock_aws.add_snapshot_ownership.assert_called_with(
-            mock_session,
-            mock_snapshot,
-            mock_region
-        )
+        mock_aws.add_snapshot_ownership.assert_called_with(mock_snapshot)
         mock_aws.copy_snapshot.assert_called_with(
             mock_snapshot_id,
             mock_region

--- a/cloudigrade/util/aws/ec2.py
+++ b/cloudigrade/util/aws/ec2.py
@@ -89,19 +89,20 @@ def get_ec2_instance(session, instance_id):
     return session.resource('ec2').Instance(instance_id)
 
 
-def get_ami(session, image_id, region):
+def get_ami(session, image_id, source_region):
     """
     Return an Amazon Machine Image running on an EC2 instance.
 
     Args:
         session (boto3.Session): A temporary session tied to a customer account
         image_id (str): An AMI ID
+        source_region (str): The region the snapshot resides in
 
     Returns:
         Image: A boto3 EC2 Image object.
 
     """
-    return session.resource('ec2', region_name=region).Image(image_id)
+    return session.resource('ec2', region_name=source_region).Image(image_id)
 
 
 def get_ami_snapshot_id(ami):
@@ -122,19 +123,21 @@ def get_ami_snapshot_id(ami):
         return mapping.get('Ebs', {}).get('SnapshotId', '')
 
 
-def get_snapshot(session, snapshot_id, region):
+def get_snapshot(session, snapshot_id, source_region):
     """
     Return an AMI Snapshot for an EC2 instance.
 
     Args:
         session (boto3.Session): A temporary session tied to a customer account
         snapshot_id (str): A snapshot ID
+        source_region (str): The region the snapshot resides in
 
     Returns:
         Snapshot: A boto3 EC2 Snapshot object.
 
     """
-    return session.resource('ec2', region_name=region).Snapshot(snapshot_id)
+    return session.resource(
+        'ec2', region_name=source_region).Snapshot(snapshot_id)
 
 
 def add_snapshot_ownership(snapshot):

--- a/cloudigrade/util/aws/ec2.py
+++ b/cloudigrade/util/aws/ec2.py
@@ -142,7 +142,7 @@ def add_snapshot_ownership(snapshot):
     Add permissions to a snapshot.
 
     Args:
-        snapshot_id (str): The id of the snapshot to modify
+        snapshot: A boto3 EC2 Snapshot object.
 
     Returns:
         None


### PR DESCRIPTION
#247 

Updates calls around `aws.add_snapshot_ownership`, fixes wrong docstrings in surrounding areas.