### PR TITLE
add header and section for new bugs to the default github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,30 @@
+This is the default new issue template! You may use the next section to enter a new user story, or use the last section to enter a new bug. Please delete this header and the other unused section before submitting this issue.
+
+---
+
 As X, I want Y so that Z.
 
-## Acceptance Criteria 
+## Acceptance Criteria
 
 - [ ] Verify
 
 ## Assumptions and Questions
 
-- 
+-
+
+---
+
+X is a bug because Y happens when I expect Z.
+
+## Steps to Reproduce
+
+1.
+1.
+
+## Expected Result
+
+-
+
+## Actual Result
+
+-


### PR DESCRIPTION
I think we're overdue for updating our default issue template with a section for entering a bug.

It sure would be nice if GitHub supported picking from different templates under different circumstances, but I think this is a good enough compromise.

This is what the updated template looks like:
https://github.com/cloudigrade/cloudigrade/blob/even-better-git-issue-template/.github/ISSUE_TEMPLATE.md