### PR TITLE
286 better handle bogus arns

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -192,7 +192,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
-    )
+    ),
+    'EXCEPTION_HANDLER': 'util.exceptions.api_exception_handler',
 }
 
 # Message and Task Queues

--- a/cloudigrade/util/aws/helper.py
+++ b/cloudigrade/util/aws/helper.py
@@ -41,16 +41,19 @@ def verify_account_access(session):
         session (boto3.Session): A temporary session tied to a customer account
 
     Returns:
-        bool: Whether role is verified.
+        tuple[bool, list]: First element of the tuple indicates if role was
+        verified, and the second element is a list of actions that failed.
 
     """
     success = True
+    failed_actions = []
     for action in cloudigrade_policy['Statement'][0]['Action']:
         if not _verify_policy_action(session, action):
             # Mark as failure, but keep looping so we can see each specific
             # failure in logs
+            failed_actions.append(action)
             success = False
-    return success
+    return success, failed_actions
 
 
 def _handle_dry_run_response_exception(action, e):

--- a/cloudigrade/util/tests/test_aws_helper.py
+++ b/cloudigrade/util/tests/test_aws_helper.py
@@ -53,7 +53,7 @@ class UtilAwsHelperTest(TestCase):
             call(mock_session, 'ec2:DescribeSnapshots'),
         ]
         mock_verify_policy_action.side_effect = [
-            True, True, True, True, True, True
+            True, True, True, True, True
         ]
         verified, failed_actions = helper.verify_account_access(mock_session)
         self.assertTrue(verified)
@@ -72,7 +72,7 @@ class UtilAwsHelperTest(TestCase):
             call(mock_session, 'ec2:DescribeSnapshots'),
         ]
         mock_verify_policy_action.side_effect = [
-            True, True, True, False, True, True
+            True, True, True, False, True
         ]
         verified, failed_actions = helper.verify_account_access(mock_session)
         self.assertFalse(verified)

--- a/cloudigrade/util/tests/test_aws_helper.py
+++ b/cloudigrade/util/tests/test_aws_helper.py
@@ -55,8 +55,9 @@ class UtilAwsHelperTest(TestCase):
         mock_verify_policy_action.side_effect = [
             True, True, True, True, True, True
         ]
-        is_verified = helper.verify_account_access(mock_session)
-        self.assertTrue(is_verified)
+        verified, failed_actions = helper.verify_account_access(mock_session)
+        self.assertTrue(verified)
+        self.assertEqual(len(failed_actions), 0)
         mock_verify_policy_action.assert_has_calls(expected_calls)
 
     @patch('util.aws.helper._verify_policy_action')
@@ -73,8 +74,9 @@ class UtilAwsHelperTest(TestCase):
         mock_verify_policy_action.side_effect = [
             True, True, True, False, True, True
         ]
-        is_verified = helper.verify_account_access(mock_session)
-        self.assertFalse(is_verified)
+        verified, failed_actions = helper.verify_account_access(mock_session)
+        self.assertFalse(verified)
+        self.assertEqual(len(failed_actions), 1)
         mock_verify_policy_action.assert_has_calls(expected_calls)
 
     def assert_verify_policy_action_success(self, action, function_name,

--- a/cloudigrade/util/tests/test_exceptions.py
+++ b/cloudigrade/util/tests/test_exceptions.py
@@ -1,0 +1,56 @@
+"""Collection of tests for ``util.exceptions`` module."""
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.test import TestCase
+from rest_framework.exceptions import APIException, NotFound
+from rest_framework.exceptions import PermissionDenied as DrfPermissionDenied
+
+from util import exceptions
+
+
+class ExceptionsTest(TestCase):
+    """Exception module test case."""
+
+    def test_api_exception_handler_apiexception_ok(self):
+        """Assert APIException is passed through for handling."""
+        mock_context = Mock()
+        exc = APIException()
+        with patch.object(exceptions, 'exception_handler') as mock_handler:
+            response = exceptions.api_exception_handler(exc, mock_context)
+            mock_handler.assert_called_with(exc, mock_context)
+            self.assertEqual(response, mock_handler.return_value)
+
+    def test_api_exception_handler_http404_replaced(self):
+        """Assert Django's Http404 is replaced with DRF's NotFound."""
+        mock_context = Mock()
+        exc = Http404()
+        with patch.object(exceptions, 'exception_handler') as mock_handler:
+            response = exceptions.api_exception_handler(exc, mock_context)
+            mock_call_args = mock_handler.call_args_list[0][0]
+            self.assertIsInstance(mock_call_args[0], NotFound)
+            self.assertEqual(mock_call_args[1], mock_context)
+            self.assertEqual(response, mock_handler.return_value)
+
+    def test_api_exception_handler_permissiondenied_replaced(self):
+        """Assert Django's PermissionDenied is replaced with DRF's version."""
+        mock_context = Mock()
+        exc = PermissionDenied()
+        with patch.object(exceptions, 'exception_handler') as mock_handler:
+            response = exceptions.api_exception_handler(exc, mock_context)
+            mock_call_args = mock_handler.call_args_list[0][0]
+            self.assertIsInstance(mock_call_args[0], DrfPermissionDenied)
+            self.assertEqual(mock_call_args[1], mock_context)
+            self.assertEqual(response, mock_handler.return_value)
+
+    def test_api_exception_handler_mystery_exception_replaced(self):
+        """Assert mystery Exception is replaced with DRF's APIException."""
+        mock_context = Mock()
+        exc = Exception()
+        with patch.object(exceptions, 'exception_handler') as mock_handler:
+            response = exceptions.api_exception_handler(exc, mock_context)
+            mock_call_args = mock_handler.call_args_list[0][0]
+            self.assertIsInstance(mock_call_args[0], APIException)
+            self.assertEqual(mock_call_args[1], mock_context)
+            self.assertEqual(response, mock_handler.return_value)


### PR DESCRIPTION
https://github.com/cloudigrade/cloudigrade/issues/286

This change actually does a couple of things:

- Explicitly handle if we don't have access to the provided ARN for account creation.
- If we have access to the ARN but the policy isn't good, expand the response with more meaningfully verbose explanation of the failures.
- In _general_ handle any non-DRF exceptions and present the simplified DRF "500 error" response so we don't leak a bunch of Django internals.

Demo: https://asciinema.org/a/182337