### PR TITLE
Make cloudigrade-test log more verbose

### DIFF
--- a/deployment/ocp/cloudigrade.yml
+++ b/deployment/ocp/cloudigrade.yml
@@ -567,7 +567,7 @@ parameters:
   required: true
 - name: DJANGO_DEBUG
   description: "Django Debug Mode"
-  value: "False"
+  value: "True"
   required: true
 - name: DJANGO_SECRET_KEY
   description: "Django Secret Key"


### PR DESCRIPTION
It would be a boon to QE if the test env logs were more verbose so if there are test failures we can know more about what was going on. Pretty sure changing this setting will do that, please advise if that is not the case.