### PR TITLE
keep kombu and pycurl because celery needs them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN useradd -r cloudigrade
 RUN yum install centos-release-scl -y \
     && yum-config-manager --enable centos-sclo-rh-testing \
     && yum install \
+        libcurl-devel \
         nmap-ncat \
         rh-postgresql96 \
         rh-postgresql96-postgresql-devel \
@@ -15,7 +16,7 @@ RUN yum install centos-release-scl -y \
 WORKDIR /opt/cloudigrade
 
 COPY requirements requirements
-RUN scl enable rh-postgresql96 rh-python36 \
+RUN PYCURL_SSL_LIBRARY=nss scl enable rh-postgresql96 rh-python36 \
     'pip install -r requirements/prod.txt' \
     && rm -rf requirements
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,22 @@ Once you have an environment set up, install our Python package requirements:
     pip install -U pip wheel tox
     pip install -r requirements/local.txt
 
+If you plan to run cloudigrade or Celery locally on macOS, the required ``pycurl`` package may fail to install or may install improperly despite ``pip install`` appearing to complete successfully. You can verify that ``pycurl`` is installed correctly by simply importing it in a Python shell like this:
+
+.. code-block:: sh
+
+   python -c 'import pycurl'
+
+If you see no output, everything is okay! Otherwise (e.g. "libcurl link-time ssl backend (openssl) is different from compile-time ssl backend (none/other)"), it may not have installed correctly. Try the following commands force it to rebuild and install with the openssl backend:
+
+.. code-block:: sh
+
+   brew install openssl
+   pip uninstall pycurl
+   PYCURL_SSL_LIBRARY=openssl pip --no-cache-dir install --install-option="--with-openssl" --install-option="--openssl-dir=$(brew --prefix)/opt/openssl" pycurl
+
+Try the aforementioned import command again, and all should be good. If not, kindly reach out to another cloudigrade developer to seek assistance!
+
 
 Configure AWS account credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,4 @@ django-rest-polymorphic==0.1.7
 django-celery-beat==1.1.1
 django-health-check==3.6.1
 djoser==1.1.5
+pycurl==7.43.0.1


### PR DESCRIPTION
This reverts commit 988dd1d1188cafbba3b8ed33f024c478020c0709.

This should resolve https://github.com/cloudigrade/cloudigrade/issues/353