### PR TITLE
Add sysconfig endpoint

### DIFF
--- a/cloudigrade/account/tests/test_views.py
+++ b/cloudigrade/account/tests/test_views.py
@@ -17,7 +17,8 @@ from account.views import (AccountViewSet,
                            InstanceEventViewSet,
                            InstanceViewSet,
                            MachineImageViewSet,
-                           ReportViewSet)
+                           ReportViewSet,
+                           SysconfigViewSet)
 from util.tests import helper as util_helper
 
 
@@ -818,3 +819,23 @@ class InstanceEventViewSetTest(TestCase):
         response = self.get_event_list_response(self.superuser, params)
         actual_events = self.get_event_ids_from_list_response(response)
         self.assertEqual(expected_events, actual_events)
+
+
+class SysconfigViewSetTest(TestCase):
+    """SysconfigViewSet test case."""
+
+    @patch('account.views._get_primary_account_id')
+    def test_list_accounts_success(self, mock_get_primary_account_id):
+        """Test listing account ids."""
+        account_id = account_helper.generate_aws_account()
+        mock_get_primary_account_id.return_value = account_id
+        user = util_helper.generate_test_user()
+        factory = APIRequestFactory()
+        request = factory.get('/sysconfig/')
+        force_authenticate(request, user=user)
+        view = SysconfigViewSet.as_view(actions={'get': 'list'})
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {'aws_account_id': account_id})

--- a/cloudigrade/account/views.py
+++ b/cloudigrade/account/views.py
@@ -10,6 +10,7 @@ from account.models import (Account,
                             InstanceEvent,
                             MachineImage)
 from account.util import convert_param_to_int
+from util.aws.sts import _get_primary_account_id
 
 
 class AccountViewSet(mixins.CreateModelMixin, viewsets.ReadOnlyModelViewSet):
@@ -134,3 +135,14 @@ class ReportViewSet(viewsets.ViewSet):
         except InvalidCloudProviderError as e:
             raise exceptions.ValidationError(detail=str(e))
         return Response(result, status=status.HTTP_200_OK)
+
+
+class SysconfigViewSet(viewsets.ViewSet):
+    """View to display our cloud account ids."""
+
+    def list(self, *args, **kwargs):
+        """Get cloud account ids currently used by this installation."""
+        response = {
+            'aws_account_id': _get_primary_account_id()
+        }
+        return Response(response)

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -191,7 +191,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
+        'dj_auth.permissions.IsAuthenticated',
     ),
     'EXCEPTION_HANDLER': 'util.exceptions.api_exception_handler',
 }

--- a/cloudigrade/config/urls.py
+++ b/cloudigrade/config/urls.py
@@ -8,7 +8,8 @@ from account.views import (AccountViewSet,
                            InstanceEventViewSet,
                            InstanceViewSet,
                            MachineImageViewSet,
-                           ReportViewSet)
+                           ReportViewSet,
+                           SysconfigViewSet)
 
 router = routers.DefaultRouter()
 router.register(r'account', AccountViewSet)
@@ -16,6 +17,7 @@ router.register(r'event', InstanceEventViewSet)
 router.register(r'instance', InstanceViewSet)
 router.register(r'image', MachineImageViewSet)
 router.register(r'report', ReportViewSet, base_name='report')
+router.register(r'sysconfig', SysconfigViewSet, base_name='sysconfig')
 
 urlpatterns = [
     url(r'^api/v1/', include(router.urls)),

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -407,3 +407,34 @@ Response:
             "Incorrect cloud_account_id type for cloud_provider \"aws\""
         ]
     }
+
+Miscellaneous Commands
+---------------
+
+Retrieve current cloud account ids used by the application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Request:
+
+.. code:: bash
+
+    http localhost:8080/api/v1/sysconfig/ "${AUTH}"
+
+Response:
+
+::
+
+    HTTP/1.1 200 OK
+    Allow: GET, HEAD, OPTIONS
+    Content-Length: 33
+    Content-Type: application/json
+    Date: Mon, 25 Jun 2018 17:22:50 GMT
+    Server: WSGIServer/0.2 CPython/3.6.5
+    Vary: Accept
+    X-Frame-Options: SAMEORIGIN
+
+    {
+        "aws_account_id": "123456789012"
+    }
+
+If you attempt to retrieve account ids without authentication you'll receive a 401 error.


### PR DESCRIPTION
This adds a /sysconfig/ endpoint that returns the cloud account the customer should use during setup.

Demo: https://asciinema.org/a/jWiiQc659pehSAVJJfI57ukWW