### PR TITLE
Add some checks for ARN validity.

### DIFF
--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -346,6 +346,15 @@ def update_from_source_kafka_message(message, headers):
         source_id = application.get("source_id")
 
         arn = authentication.get("username") or authentication.get("password")
+        if not arn:
+            logger.info(_("Could not update CloudAccount with no ARN provided."))
+            error_code = error_codes.CG2004
+            error_code.log_internal_message(
+                logger, {"authentication_id": authentication_id}
+            )
+            error_code.notify(account_number, application_id)
+            return
+
         # If the Authentication being updated is arn, do arn things.
         # The kafka message does not always include authtype, so we get this from
         # the sources API call

--- a/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
@@ -1,0 +1,43 @@
+"""Collection of tests for api.cloud.aws.util.update_aws_cloud_account."""
+from unittest.mock import patch
+
+import faker
+from django.test import TestCase
+
+from api.clouds.aws import util
+from api.tests import helper as api_helper
+from util.tests import helper as util_helper
+
+_faker = faker.Faker()
+
+
+class UpdateAWSClountTest(TestCase):
+    """Test cases for api.cloud.aws.util.update_aws_cloud_account."""
+
+    def setUp(self):
+        """Set up shared variables."""
+        self.user = util_helper.generate_test_user()
+        self.aws_account_id = util_helper.generate_dummy_aws_account_id()
+        self.arn = util_helper.generate_dummy_arn(account_id=self.aws_account_id)
+        self.name = _faker.word()
+        self.auth_id = _faker.pyint()
+        self.app_id = _faker.pyint()
+        self.source_id = _faker.pyint()
+
+        self.clount = api_helper.generate_cloud_account(
+            arn=self.arn,
+            aws_account_id=self.aws_account_id,
+            user=self.user,
+            name=self.name,
+            platform_authentication_id=self.auth_id,
+            platform_application_id=self.app_id,
+            platform_source_id=self.source_id,
+        )
+
+    @patch("api.error_codes.notify_sources_application_availability")
+    def test_update_aws_clount_notifies_sources_invalid_arn(self, mock_notify_sources):
+        """Test update_aws_cloud_account notifies sources if ARN is invalid."""
+        util.update_aws_cloud_account(
+            self.clount, "INVALID", self.name, self.auth_id, self.source_id
+        )
+        mock_notify_sources.assert_called()


### PR DESCRIPTION
- If ARN provided in update from sources is blank, notify sources and do not update
- If ARN provided in update from sources is invalid, notify sources and do not update