### PR TITLE
Change arn update logic.

### DIFF
--- a/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
@@ -2,11 +2,12 @@
 from unittest.mock import patch
 
 import faker
-from django.contrib.auth.models import User
 from django.test import TestCase
 
+
 from api.clouds.aws import util
-from api.models import CloudAccount
+from api.clouds.aws.models import AwsCloudAccount
+from api.models import CloudAccount, Instance
 from api.tests import helper as api_helper
 from util.tests import helper as util_helper
 
@@ -44,24 +45,76 @@ class UpdateAWSClountTest(TestCase):
         )
         mock_notify_sources.assert_called()
 
-    @patch("api.clouds.aws.tasks.configure_customer_aws_and_create_cloud_account")
     @patch("api.error_codes.notify_sources_application_availability")
     @patch.object(CloudAccount, "disable")
     @patch.object(CloudAccount, "enable")
-    def test_update_aws_clount_different_aws_id_recreates_user(
+    def test_update_aws_clount_different_aws_account_id_success(
         self,
         mock_enable,
         mock_disable,
         mock_notify_sources,
-        mock_configure_and_create_clount,
     ):
-        """Test update_aws_cloud_account creates a new user."""
+        """Test update_aws_cloud_account works."""
         aws_account_id2 = util_helper.generate_dummy_aws_account_id()
         arn2 = util_helper.generate_dummy_arn(account_id=aws_account_id2)
+
+        api_helper.generate_instance(self.clount)
+
         util.update_aws_cloud_account(
             self.clount, arn2, self.account_number, self.auth_id, self.source_id
         )
-        self.assertEqual(1, User.objects.all().count())
+        self.assertTrue(AwsCloudAccount.objects.filter(account_arn=arn2).exists())
+        self.assertEqual(0, Instance.objects.all().count())
 
-        new_user = User.objects.get(username=self.account_number)
-        self.assertNotEqual(self.user.id, new_user.id)
+    @patch("api.clouds.aws.util._notify_error_with_generic_message_for_different_user")
+    @patch("api.error_codes.notify_sources_application_availability")
+    @patch.object(CloudAccount, "disable")
+    @patch.object(CloudAccount, "enable")
+    def test_update_aws_clount_different_aws_account_id_fails_arn_already_exists(
+        self,
+        mock_enable,
+        mock_disable,
+        mock_notify_sources,
+        mock_notify_error,
+    ):
+        """Test update_aws_cloud_account fails for duplicate arn."""
+        aws_account_id2 = util_helper.generate_dummy_aws_account_id()
+        arn2 = util_helper.generate_dummy_arn(account_id=aws_account_id2)
+
+        api_helper.generate_cloud_account(
+            arn=arn2,
+            aws_account_id=aws_account_id2,
+        )
+
+        util.update_aws_cloud_account(
+            self.clount, arn2, self.account_number, self.auth_id, self.source_id
+        )
+
+        mock_notify_error.assert_called()
+
+    @patch("api.clouds.aws.util._notify_error_with_generic_message_for_different_user")
+    @patch("api.error_codes.notify_sources_application_availability")
+    @patch.object(CloudAccount, "disable")
+    @patch.object(CloudAccount, "enable")
+    def test_update_aws_clount_different_aws_account_id_fails_account_id_already_exists(
+        self,
+        mock_enable,
+        mock_disable,
+        mock_notify_sources,
+        mock_notify_error,
+    ):
+        """Test update_aws_cloud_account fails for duplicate aws_account_id."""
+        aws_account_id2 = util_helper.generate_dummy_aws_account_id()
+        arn2 = util_helper.generate_dummy_arn(account_id=aws_account_id2)
+        arn3 = util_helper.generate_dummy_arn(account_id=aws_account_id2)
+
+        api_helper.generate_cloud_account(
+            arn=arn2,
+            aws_account_id=aws_account_id2,
+        )
+
+        util.update_aws_cloud_account(
+            self.clount, arn3, self.account_number, self.auth_id, self.source_id
+        )
+
+        mock_notify_error.assert_called()

--- a/cloudigrade/api/tests/tasks/test_update_from_source_kafka_message.py
+++ b/cloudigrade/api/tests/tasks/test_update_from_source_kafka_message.py
@@ -161,10 +161,10 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
 
     @patch("util.insights.get_sources_application")
     @patch("api.models.notify_sources_application_availability")
-    @patch("api.clouds.aws.tasks.configure_customer_aws_and_create_cloud_account")
     @patch("util.insights.get_sources_authentication")
+    @patch.object(CloudAccount, "enable")
     def test_update_from_sources_kafka_message_new_aws_account_id(
-        self, mock_get_auth, mock_create_clount, mock_notify_sources, mock_get_app
+        self, mock_enable, mock_get_auth, mock_notify_sources, mock_get_app
     ):
         """
         Assert the new cloud account created for new aws_account_id.
@@ -189,9 +189,7 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
             mock_assume_role.return_value = util_helper.generate_dummy_role()
             tasks.update_from_source_kafka_message(message, headers)
 
-        self.assertFalse(CloudAccount.objects.filter(id=self.clount.id).exists())
-
-        mock_create_clount.delay.assert_called()
+        mock_enable.assert_called()
 
     @patch("api.tasks.insights.list_sources_application_authentications")
     @patch("api.tasks.update_aws_cloud_account")


### PR DESCRIPTION
When we get a sources update message and the arn has a different aws_account_id,
instead of deleting the account (and thus the user) we now disable the account,
delete all the instance related to it, update the arn and then enable it.

This fixes the error where the user is deleted when we delete the account,
and not recreated when we create the new clount. functionally there should be
no difference, except that the id for the clount no longer changes when the arn
is updated.