### PR TITLE
782 deadlock tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ If you see no output, everything is okay! Otherwise (e.g. "libcurl link-time ssl
     poetry run pip uninstall pycurl -y
 
     BREW_PATH=$(brew --prefix)
-    export LDFLAGS="-L${BREW_PATH}/opt/curl/lib"
-    export CPPFLAGS="-I${BREW_PATH}/opt/curl/include"
+    export LDFLAGS="-L${BREW_PATH}/opt/curl/lib -L${BREW_PATH}/opt/openssl/lib"
+    export CPPFLAGS="-I${BREW_PATH}/opt/curl/include -I${BREW_PATH}/opt/openssl/include"
     export PYCURL_SSL_LIBRARY="openssl"
 
     poetry install

--- a/cloudigrade/api/clouds/aws/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/aws/tasks/onboarding.py
@@ -2,7 +2,6 @@
 import logging
 
 from django.contrib.auth.models import User
-from django.db import transaction
 from django.utils.translation import gettext as _
 from rest_framework.serializers import ValidationError
 
@@ -129,7 +128,7 @@ def initial_aws_describe_instances(account_id):
         return
 
     # Lock the task at a user level. A user can only run one task at a time.
-    with transaction.atomic(), lock_task_for_user_ids([user_id]):
+    with lock_task_for_user_ids([user_id]):
         try:
             AwsCloudAccount.objects.get(pk=account_id)
             new_ami_ids = create_new_machine_images(session, instances_data)

--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -254,7 +254,7 @@ def delete_from_sources_kafka_message(message, headers, event_type):  # noqa: C9
         # Using the UserTaskLock *should* fix the issue of Django not getting a
         # row-level lock in the DB for each CloudAccount we want to delete until
         # after all of the pre_delete logic completes
-        with transaction.atomic(), lock_task_for_user_ids([cloud_account.user.id]):
+        with lock_task_for_user_ids([cloud_account.user.id]):
             # Call delete on the CloudAccount queryset instead of the specific
             # cloud_account. Why? A queryset delete does not raise DoesNotExist
             # exceptions if the cloud_account has already been deleted.
@@ -580,7 +580,7 @@ def calculate_max_concurrent_usage_task(self, date, user_id):
         # Lock the task at a user level. A user can only run one task at a time.
         # If another user task is already running, then don't start the
         # concurrent usage calculation task
-        with transaction.atomic(), lock_task_for_user_ids([user_id]):
+        with lock_task_for_user_ids([user_id]):
             calculate_max_concurrent_usage(date, user_id)
     except Exception:
         calculation_task.status = ConcurrentUsageCalculationTask.ERROR

--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -52,6 +52,7 @@ from api.models import (
     InstanceEvent,
     MachineImage,
     Run,
+    UserTaskLock,
 )
 from api.util import (
     calculate_max_concurrent_usage,
@@ -170,6 +171,7 @@ def create_from_sources_kafka_message(message, headers):  # noqa: C901
                 _("User %s was not found and has been created."),
                 account_number,
             )
+            UserTaskLock.objects.get_or_create(user=user)
 
     # Conditionalize the logic for different cloud providers
     if authtype == settings.SOURCES_CLOUDMETER_ARN_AUTHTYPE:

--- a/cloudigrade/util/tests/test_misc.py
+++ b/cloudigrade/util/tests/test_misc.py
@@ -80,7 +80,7 @@ class LockUserTaskTest(TransactionTestCase):
             generate_verify_task=False,
         )
 
-        with transaction.atomic(), lock_task_for_user_ids([account.user.id]):
+        with lock_task_for_user_ids([account.user.id]):
             CloudAccount.objects.filter(id=account.id).delete()
 
         self.assertEqual(CloudAccount.objects.all().count(), 0)
@@ -99,7 +99,7 @@ class LockUserTaskTest(TransactionTestCase):
         )
         UserTaskLock.objects.create(user=account.user)
         with self.assertRaises(transaction.TransactionManagementError):
-            with transaction.atomic(), lock_task_for_user_ids([account.user.id]):
+            with lock_task_for_user_ids([account.user.id]):
                 CloudAccount.objects.filter(id=account.id).delete()
                 raise transaction.TransactionManagementError
 


### PR DESCRIPTION
This PR has a few minor adjustments to transactions and UserTaskLock with the hope of reducing the risk of deadlocks in some situations. For https://github.com/cloudigrade/cloudigrade/issues/782.

I moved UserTaskLock creation earlier in the authentication and task processes to try to avoid the situation where two worker tasks are simultaneously processing Kafka messages for the same user for the _first_ time, and both of them manage to create and save distinct UserTaskLock instances for that user.

I moved the transaction atomic context into lock_task_for_user_ids to guarantee that it's always used consistently. Outside of a transaction, "select for update" queries don't actually keep the row-level lock.