### PR TITLE
810 null image

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/cloudtrail.py
+++ b/cloudigrade/api/clouds/aws/tasks/cloudtrail.py
@@ -89,7 +89,7 @@ def _process_cloudtrail_message(message):
         raw_content = aws.get_object_content_from_s3(bucket, key)
         content = json.loads(raw_content)
         logs.append((content, bucket, key))
-        logger.debug(
+        logger.info(
             _("Read CloudTrail log file from bucket %(bucket)s object key %(key)s"),
             {"bucket": bucket, "key": key},
         )

--- a/cloudigrade/api/tests/util/test_calculate_max_concurrent_usage.py
+++ b/cloudigrade/api/tests/util/test_calculate_max_concurrent_usage.py
@@ -154,6 +154,28 @@ class CalculateMaxConcurrentUsageTest(TestCase):
         usage = calculate_max_concurrent_usage(request_date, user_id=self.user1.id)
         self.assertMaxConcurrentUsage(usage, expected_date, 0)
 
+    def test_single_no_image_run_within_day(self):
+        """Test with a single no-image instance run within the day."""
+        mystery_instance = api_helper.generate_instance(
+            self.user1account1, image=None, no_image=True
+        )
+        api_helper.generate_single_run(
+            mystery_instance,
+            (
+                util_helper.utc_dt(2019, 5, 1, 1, 0, 0),
+                util_helper.utc_dt(2019, 5, 1, 2, 0, 0),
+            ),
+            image=None,
+            no_image=True,
+        )
+        request_date = datetime.date(2019, 5, 1)
+        expected_date = request_date
+        expected_instances = 0
+
+        usage = calculate_max_concurrent_usage(request_date, user_id=self.user1.id)
+        self.assertEqual(len(usage.maximum_counts), 0)
+        self.assertMaxConcurrentUsage(usage, expected_date, expected_instances)
+
     def test_single_run_overlapping_day_start(self):
         """Test with a RHEL instance run overlapping the start of the day."""
         rhel_instance = api_helper.generate_instance(

--- a/cloudigrade/api/util.py
+++ b/cloudigrade/api/util.py
@@ -322,7 +322,7 @@ def calculate_max_concurrent_usage(date, user_id):
                 ),
                 {"number": number, "user_id": user_id, "date": date},
             )
-        if not run.machineimage.rhel:
+        if not run.machineimage or not run.machineimage.rhel:
             continue
         rhel_on_offs.append(
             (


### PR DESCRIPTION
https://github.com/cloudigrade/cloudigrade/issues/810

This fixes concurrent calculation to handle the case when an instance has no known image.

A separate PR may come later to improve handling for out-of-order events which is what I believe was the root cause for this incident. We don't necessarily want to _require_ all instances to have a fully defined image since it may still be possible for us to process not-fully-defined instance events after the instance was terminated and we cannot actively describe it.