### PR TITLE
Log clount id instead of user id if user is already deleted.

### DIFF
--- a/cloudigrade/api/models.py
+++ b/cloudigrade/api/models.py
@@ -254,10 +254,7 @@ def cloud_account_post_delete_callback(*args, **kwargs):
             )
             instance.user.delete()
     except User.DoesNotExist:
-        logger.info(
-            _("User %s has already been deleted."),
-            instance.user,
-        )
+        logger.info(_("User for clount id %s has already been deleted."), instance.id)
 
 
 class MachineImage(ExportModelOperationsMixin("MachineImage"), BaseGenericModel):


### PR DESCRIPTION
Otherwise a User.DoesNotExist error is raised.