### PR TITLE
if set, use CLOUDIGRADE_VERSION as Sentry release in Django and Celery apps

### DIFF
--- a/cloudigrade/config/celery.py
+++ b/cloudigrade/config/celery.py
@@ -6,6 +6,7 @@ import django
 import environ
 import sentry_sdk
 from celery import Celery, current_task, signals
+from django.conf import settings
 from sentry_sdk.integrations.celery import CeleryIntegration
 
 from util.middleware import local
@@ -26,6 +27,11 @@ logger.info("Celery setup.")
 
 if env("CELERY_ENABLE_SENTRY", default=False):
     logger.info("Enabling sentry.")
+    CELERY_SENTRY_ENVIRONMENT = (
+        settings.CLOUDIGRADE_VERSION
+        if settings.CLOUDIGRADE_VERSION
+        else env("CELERY_SENTRY_RELEASE")
+    )
     sentry_sdk.init(
         dsn=env("CELERY_SENTRY_DSN"),
         environment=env("CELERY_SENTRY_ENVIRONMENT"),

--- a/cloudigrade/config/settings/prod.py
+++ b/cloudigrade/config/settings/prod.py
@@ -32,10 +32,14 @@ QUEUE_EXCHANGE_NAME = None
 STATIC_ROOT = env("DJANGO_STATIC_ROOT", default="/srv/cloudigrade/static/")
 
 if env.bool("API_ENABLE_SENTRY", default=False):
+    DJANGO_SENTRY_RELEASE = (
+        CLOUDIGRADE_VERSION if CLOUDIGRADE_VERSION else env("DJANGO_SENTRY_RELEASE")
+    )
+
     sentry_sdk.init(
         dsn=env("DJANGO_SENTRY_DSN"),
         environment=env("DJANGO_SENTRY_ENVIRONMENT"),
-        release=env("DJANGO_SENTRY_RELEASE"),
+        release=DJANGO_SENTRY_RELEASE,
         traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=0.0),
         integrations=[DjangoIntegration()],
         send_default_pii=True,


### PR DESCRIPTION
This "release" value shows up in Sentry issues here:

![sentry-release](https://user-images.githubusercontent.com/1472326/111676762-e2b1b880-87f4-11eb-8703-4887d2b213b8.png)

Since we already specify the environment as "stage" or "prod", putting the same value in the release field is redundant. Using the actual cloudigrade version could help us to identify when regressions are introduced and resolved.