### PR TITLE
log error and schedule new ConcurrentUsageCalculationTask if expected task is not found during processing

### DIFF
--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -59,6 +59,7 @@ from api.util import (
     calculate_max_concurrent_usage_from_runs,
     normalize_runs,
     recalculate_runs,
+    schedule_concurrent_calculation_task,
 )
 from util import aws
 from util.celery import retriable_shared_task
@@ -596,7 +597,21 @@ def calculate_max_concurrent_usage_task(self, date, user_id):
 
     # Set task to running
     task_id = self.request.id
-    calculation_task = ConcurrentUsageCalculationTask.objects.get(task_id=task_id)
+    try:
+        calculation_task = ConcurrentUsageCalculationTask.objects.get(task_id=task_id)
+    except ConcurrentUsageCalculationTask.DoesNotExist:
+        # This probably shouldn't happen, but this error that suggest it does:
+        # https://sentry.io/organizations/cloudigrade/issues/2299804963/
+        # Until we can figure out the root cause of tasks going missing, let's log an
+        # error here with details and schedule a new calculation task.
+        logger.error(
+            'ConcurrentUsageCalculationTask not found for task ID "%(task_id)s"! '
+            'Scheduling a new task for user_id "%(user_id)s" date "%(date)s".',
+            {"task_id": task_id, "user_id": user_id, "date": date},
+        )
+        schedule_concurrent_calculation_task(date, user_id)
+        return
+
     calculation_task.status = ConcurrentUsageCalculationTask.RUNNING
     calculation_task.save()
 


### PR DESCRIPTION
Hopefully this helps with the alert noise for https://github.com/cloudigrade/cloudigrade/issues/843

The root cause of how the ConcurrentUsageCalculationTask went missing is a total mystery to me. This change should log a message and attempt to recover. Future investigations and changes may be required if we keep seeing this _new_ log message more than once.