### PR TITLE
cancel the task object, not the task function bind

### DIFF
--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -638,7 +638,7 @@ def calculate_max_concurrent_usage_task(self, date, user_id):
         )
         for task in newer_tasks:
             logger.info("newer task %(task)s", {"task": task})
-        self.cancel()
+        calculation_task.cancel()
         return
 
     logger.info(

--- a/cloudigrade/api/tests/tasks/test_calculate_max_concurrent_usage_task.py
+++ b/cloudigrade/api/tests/tasks/test_calculate_max_concurrent_usage_task.py
@@ -65,8 +65,6 @@ class CalculateMaxConcurrentUsageTaskTest(TestCase):
 
     def test_task_cancel_if_newer_task_is_scheduled(self):
         """Test cancel if newer scheduled task is scheduled with same user and date."""
-        calculate_max_concurrent_usage_task.cancel = MagicMock()
-
         task_id = uuid4()
         request_date = datetime.date(2019, 5, 1)
         concurrent_task = ConcurrentUsageCalculationTask(
@@ -82,10 +80,11 @@ class CalculateMaxConcurrentUsageTaskTest(TestCase):
 
         concurrent_task.save = MagicMock()
 
-        calculate_max_concurrent_usage_task.push_request(id=task_id)
-        calculate_max_concurrent_usage_task.run(str(request_date), self.user.id)
+        with patch.object(ConcurrentUsageCalculationTask, "cancel") as mock_cancel:
+            calculate_max_concurrent_usage_task.push_request(id=task_id)
+            calculate_max_concurrent_usage_task.run(str(request_date), self.user.id)
 
-        calculate_max_concurrent_usage_task.cancel.assert_called()
+        mock_cancel.assert_called()
 
         newer_task.refresh_from_db()
         self.assertEqual(


### PR DESCRIPTION
fix a bug in #861 and maybe better handle #858