### PR TITLE
remove redundant exception logging in get_ami

### DIFF
--- a/cloudigrade/util/aws/ec2.py
+++ b/cloudigrade/util/aws/ec2.py
@@ -176,7 +176,6 @@ def get_ami(session, image_id, source_region):
         image = session.resource("ec2", region_name=source_region).Image(image_id)
         check_image_state(image)
     except AwsImageError as e:
-        logger.exception(e)
         logger.info(
             _(
                 "Failed to get AMI %(image_id)s in %(source_region)s. %(message)s",


### PR DESCRIPTION
for https://github.com/cloudigrade/cloudigrade/issues/865

the `logger.exception` is redundant because we already log the exception at `info` level on the very next line. Since we do handle this case normally the rest of the way up the call stack, we don't need to be so noisy about it in the logs.