### PR TITLE
Fixed an issue where the pagination links returned were improperly formed.

### DIFF
--- a/cloudigrade/api/tests/test_appconfig.py
+++ b/cloudigrade/api/tests/test_appconfig.py
@@ -1,0 +1,142 @@
+"""Collection of tests for application configuration, IPP12, etc."""
+import http
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.tests import helper as api_helper
+from util.tests import helper as util_helper
+
+
+class AppConfigSetTest(TestCase):
+    """AppConfigSet test case."""
+
+    def setUp(self):
+        """Set up a bunch of test data."""
+        self.user1 = util_helper.generate_test_user()
+        self.user2 = util_helper.generate_test_user()
+
+        self.account1 = api_helper.generate_cloud_account(user=self.user1)
+        self.account2 = api_helper.generate_cloud_account(user=self.user2)
+
+        self.image_plain = api_helper.generate_image()
+        self.image_windows = api_helper.generate_image(is_windows=True)
+        self.image_rhel = api_helper.generate_image(rhel_detected=True)
+        self.image_ocp = api_helper.generate_image(openshift_detected=True)
+
+        self.instance1 = api_helper.generate_instance(
+            cloud_account=self.account1, image=self.image_plain
+        )
+        self.instance2 = api_helper.generate_instance(
+            cloud_account=self.account1, image=self.image_windows
+        )
+        self.instance3 = api_helper.generate_instance(
+            cloud_account=self.account1, image=self.image_rhel
+        )
+        self.instance4 = api_helper.generate_instance(
+            cloud_account=self.account1, image=self.image_ocp
+        )
+
+    def test_pagination_links(self):
+        """
+        Test proper pagination links do not include duplicate application prefix.
+
+        This test asserts that the pagination links returned do not include
+        the duplicate /api/cloudigrade application prefix.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.user1)
+        data = {"limit": 1}
+        response = client.get(
+            "/api/cloudigrade/v2/instances/", data=data, format="json"
+        )
+        body = response.json()
+
+        self.assertEquals(body["meta"]["count"], 4)
+        self.assertEquals(len(body["data"]), 1)
+
+        link_first = body["links"]["first"]
+        self.assertNotIn("/api/cloudigrade/api/cloudigrade", link_first)
+
+        link_next = body["links"]["next"]
+        self.assertNotIn("/api/cloudigrade/api/cloudigrade", link_next)
+
+        link_last = body["links"]["last"]
+        self.assertNotIn("/api/cloudigrade/api/cloudigrade", link_last)
+
+    def test_valid_pagination_links(self):
+        """
+        Test that pagination links are reachable.
+
+        This test asserts that the pagination links returned are
+        properly configured and reachable.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.user1)
+        data = {"limit": 1}
+        response = client.get(
+            "/api/cloudigrade/v2/instances/", data=data, format="json"
+        )
+        body = response.json()
+
+        self.assertEquals(body["meta"]["count"], 4)
+        self.assertEquals(len(body["data"]), 1)
+
+        link_next = body["links"]["next"]
+        response = client.get(link_next, data=data, format="json")
+        body = response.json()
+
+        self.assertEqual(response.status_code, http.HTTPStatus.OK)
+        self.assertEquals(len(body["data"]), 1)
+
+    def test_internal_pagination_links(self):
+        """
+        Test proper internal links do not include duplicate application prefix.
+
+        This test asserts that the pagination links returned do not include
+        the duplicate /api/cloudigrade application prefix.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.user1)
+        data = {"limit": 1}
+        response = client.get(
+            "/internal/api/cloudigrade/v1/accounts/", data=data, format="json"
+        )
+        body = response.json()
+
+        self.assertEquals(body["meta"]["count"], 2)
+        self.assertEquals(len(body["data"]), 1)
+
+        link_first = body["links"]["first"]
+        self.assertNotIn("/api/cloudigrade/internal", link_first)
+
+        link_next = body["links"]["next"]
+        self.assertNotIn("/api/cloudigrade/internal", link_next)
+
+        link_last = body["links"]["last"]
+        self.assertNotIn("/api/cloudigrade/internal", link_last)
+
+    def test_valid_internal_pagination_links(self):
+        """
+        Test that internal pagination links are reachable.
+
+        This test asserts that the internal pagination links returned are
+        properly configured and reachable.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.user1)
+        data = {"limit": 1}
+        response = client.get(
+            "/internal/api/cloudigrade/v1/accounts/", data=data, format="json"
+        )
+        body = response.json()
+
+        self.assertEquals(body["meta"]["count"], 2)
+        self.assertEquals(len(body["data"]), 1)
+
+        link_next = body["links"]["next"]
+        response = client.get(link_next, data=data, format="json")
+        body = response.json()
+
+        self.assertEqual(response.status_code, http.HTTPStatus.OK)
+        self.assertEquals(len(body["data"]), 1)

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -293,8 +293,6 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "util.exceptions.api_exception_handler",
 }
 
-INSIGHTS_PAGINATION_APP_PATH = "/api/cloudigrade"
-
 # Message and Task Queues
 
 # For convenience in development environments, find defaults gracefully here.

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -80,7 +80,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 1195
+    Content-Length: 1163
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -130,8 +130,8 @@ Response:
             }
         ],
         "links": {
-            "first": "/api/cloudigrade/api/cloudigrade/v2/accounts/?limit=10&offset=0",
-            "last": "/api/cloudigrade/api/cloudigrade/v2/accounts/?limit=10&offset=0",
+            "first": "/api/cloudigrade/v2/accounts/?limit=10&offset=0",
+            "last": "/api/cloudigrade/v2/accounts/?limit=10&offset=0",
             "next": null,
             "previous": null
         },
@@ -203,7 +203,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 2646
+    Content-Length: 2614
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -305,8 +305,8 @@ Response:
             }
         ],
         "links": {
-            "first": "/api/cloudigrade/api/cloudigrade/v2/instances/?limit=10&offset=0",
-            "last": "/api/cloudigrade/api/cloudigrade/v2/instances/?limit=10&offset=0",
+            "first": "/api/cloudigrade/v2/instances/?limit=10&offset=0",
+            "last": "/api/cloudigrade/v2/instances/?limit=10&offset=0",
             "next": null,
             "previous": null
         },
@@ -375,7 +375,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 2402
+    Content-Length: 2370
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -462,8 +462,8 @@ Response:
             }
         ],
         "links": {
-            "first": "/api/cloudigrade/api/cloudigrade/v2/instances/?limit=10&offset=0&running_since=2020-05-18+13%3A51%3A59.722367%2B00%3A00",
-            "last": "/api/cloudigrade/api/cloudigrade/v2/instances/?limit=10&offset=0&running_since=2020-05-18+13%3A51%3A59.722367%2B00%3A00",
+            "first": "/api/cloudigrade/v2/instances/?limit=10&offset=0&running_since=2020-05-18+13%3A51%3A59.722367%2B00%3A00",
+            "last": "/api/cloudigrade/v2/instances/?limit=10&offset=0&running_since=2020-05-18+13%3A51%3A59.722367%2B00%3A00",
             "next": null,
             "previous": null
         },
@@ -493,7 +493,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 6750
+    Content-Length: 6718
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -724,8 +724,8 @@ Response:
             }
         ],
         "links": {
-            "first": "/api/cloudigrade/api/cloudigrade/v2/images/?limit=10&offset=0",
-            "last": "/api/cloudigrade/api/cloudigrade/v2/images/?limit=10&offset=0",
+            "first": "/api/cloudigrade/v2/images/?limit=10&offset=0",
+            "last": "/api/cloudigrade/v2/images/?limit=10&offset=0",
             "next": null,
             "previous": null
         },
@@ -829,7 +829,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 19939
+    Content-Length: 19907
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -2224,8 +2224,8 @@ Response:
             }
         ],
         "links": {
-            "first": "/api/cloudigrade/api/cloudigrade/v2/concurrent/?limit=10&offset=0&start_date=2020-05-11",
-            "last": "/api/cloudigrade/api/cloudigrade/v2/concurrent/?limit=10&offset=0&start_date=2020-05-11",
+            "first": "/api/cloudigrade/v2/concurrent/?limit=10&offset=0&start_date=2020-05-11",
+            "last": "/api/cloudigrade/v2/concurrent/?limit=10&offset=0&start_date=2020-05-11",
             "next": null,
             "previous": null
         },


### PR DESCRIPTION
Fixed an issue where the pagination links returned included a duplicate of the application prefix.

While the prefix was necessary in the early days of the insights platform implementation, this is no longer needed.
As per the drf-insights-pagination https://pypi.org/project/drf-insights-pagination doc, we just won't define the INSIGHTS_PAGINATION_APP_PATH.

Tests added to verify the links returned for both external and internal API's don't include the additional /api/cloudigrade/ prefix, and to also trigger a get of the next link to validate the URL.

Fixes #851 