### PR TITLE
add psql cli tools to cloudigrade image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ RUN microdnf install shadow-utils \
 	&& useradd -r cloudigrade \
 	&& microdnf clean all
 
+RUN microdnf install libicu \
+    && curl -O https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-8.3-x86_64/postgresql11-libs-11.9-4PGDG.rhel8.x86_64.rpm \
+    && curl -O https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-8.3-x86_64/postgresql11-11.9-4PGDG.rhel8.x86_64.rpm \
+    && rpm -iv postgresql11-libs-11.9-4PGDG.rhel8.x86_64.rpm \
+    && rpm --nodeps -iv postgresql11-11.9-4PGDG.rhel8.x86_64.rpm \
+    && rm -f postgresql11-libs-11.9-4PGDG.rhel8.x86_64.rpm postgresql11-11.9-4PGDG.rhel8.x86_64.rpm \
+    && microdnf clean all
+
 COPY pyproject.toml poetry.lock ./
 RUN microdnf update \
     && microdnf install git which procps-ng nmap-ncat libcurl-devel gcc openssl-devel python38-devel python38-pip redhat-rpm-config -y \


### PR DESCRIPTION
I'm adding these to help diagnose some issues in our deployed
environments. This might be temporary, but it might also be useful
to keep around for future investigations.

Yes, these curls and rpm commands are kind of ugly, but neither UBI
nor EPEL include appropriate postgresql packages. Also, we have to
tell rpm "--nodeps" because we don't want it to pull in systemd and
all of *its* dependencies (which postgresql11 declares but really
only needs if you want to run the psql *server*).