### PR TITLE
move import and add comment to indicate risk of using _get_primary_account_id inside the prod config

### DIFF
--- a/cloudigrade/config/settings/prod.py
+++ b/cloudigrade/config/settings/prod.py
@@ -2,7 +2,6 @@
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from util.aws.sts import _get_primary_account_id
 from .base import *
 
 IS_PRODUCTION = CLOUDIGRADE_ENVIRONMENT == "prod"
@@ -12,10 +11,20 @@ DJANGO_DEBUG = "False"
 CLOUDIGRADE_ENVIRONMENT = env("CLOUDIGRADE_ENVIRONMENT")
 
 HOUNDIGRADE_AWS_AVAILABILITY_ZONE = "us-east-1a"
-HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME = f"cloudigrade-ecs-asg-{CLOUDIGRADE_ENVIRONMENT}"
+HOUNDIGRADE_AWS_AUTOSCALING_GROUP_NAME = (
+    f"cloudigrade-ecs-asg-{CLOUDIGRADE_ENVIRONMENT}"
+)
 HOUNDIGRADE_ECS_CLUSTER_NAME = f"cloudigrade-ecs-{CLOUDIGRADE_ENVIRONMENT}"
 
 AWS_NAME_PREFIX = f"{CLOUDIGRADE_ENVIRONMENT}-"
+
+# This specific import must come *after* base because of a fragile import chain.
+# Also, if we're not careful about what we import within util.aws.sts or anything it
+# imports, we might explode or get stuck in an import loop.
+# TODO revisit this later.
+# Maybe instead of calling _get_primary_account_id we should invoke boto here directly?
+# Or maybe we should read another (redundant) environment variable for the account ID?
+from util.aws.sts import _get_primary_account_id
 
 AWS_CLOUDTRAIL_EVENT_URL = f"https://sqs.us-east-1.amazonaws.com/{_get_primary_account_id()}/cloudigrade-cloudtrail-s3-{CLOUDIGRADE_ENVIRONMENT}"
 AWS_S3_BUCKET_NAME = f"cloudigrade-{CLOUDIGRADE_ENVIRONMENT}"


### PR DESCRIPTION
Hopefully this will heal our ailing CI+QA deployments.

This is a followup to https://github.com/cloudigrade/cloudigrade/pull/876 in support of https://github.com/cloudigrade/cloudigrade/issues/738