### PR TITLE
log response from autoscaling.update_auto_scaling_group for future debugging

### DIFF
--- a/cloudigrade/util/aws/autoscaling.py
+++ b/cloudigrade/util/aws/autoscaling.py
@@ -85,6 +85,9 @@ def set_scale(name, min_size, max_size, desired_capacity):
         MaxSize=max_size,
         DesiredCapacity=desired_capacity,
     )
+    logger.info(
+        "update_auto_scaling_group response: %(response)s", {"response": response}
+    )
     return response
 
 


### PR DESCRIPTION
I locally executed some `autoscaling.update_auto_scaling_group` calls to a real AWS account and ASG to see what the response object looks like. It's normally a simple dict that looks like this:

```
>>> response = autoscaling.update_auto_scaling_group(AutoScalingGroupName=name, MinSize=1, MaxSize=1, DesiredCapacity=1)
>>> type(response)
<class 'dict'>
>>> response
{'ResponseMetadata': {'RequestId': 'fcec644d-9e6e-423c-8cc2-cdd085576ced', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': 'fcec644d-9e6e-423c-8cc2-cdd085576ced', 'content-type': 'text/xml', 'content-length': '231', 'date': 'Tue, 27 Apr 2021 18:17:02 GMT'}, 'RetryAttempts': 0}}
```

I couldn't think of a way to make the response not-okay. Giving bad inputs always resulted in a `ClientError` exception being raised. For example:

```
>>> response = autoscaling.update_auto_scaling_group(AutoScalingGroupName=name, MinSize=99999, MaxSize=1, DesiredCapacity=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 626, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the UpdateAutoScalingGroup operation: Max bound, 1, must be greater than or equal to min bound, 99999
>>>
>>> response = autoscaling.update_auto_scaling_group(AutoScalingGroupName=name, MinSize=-1, MaxSize=1, DesiredCapacity=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 626, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the UpdateAutoScalingGroup operation: Min bound, -1, must be non-negative
>>>
>>> response = autoscaling.update_auto_scaling_group(AutoScalingGroupName="totally-real-not-fake-name", MinSize=1, MaxSize=1, DesiredCapacity=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/cloudigrade-1DDoCAbr-py3.8/lib/python3.8/site-packages/botocore/client.py", line 626, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the UpdateAutoScalingGroup operation: AutoScalingGroup name not found - null
>>>
```

I'm not sure exactly how useful this will be in the future, but it's something? 🤷 