### PR TITLE
call process_instance_event for any new events created by create_missing_power_off_aws_instance_events

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -500,7 +500,7 @@ def create_missing_power_off_aws_instance_events(account, instances_data):
                 ),
             )
             .order_by("-occurred_at")
-            .last()
+            .first()
         )
         if (
             last_occurred_power_event


### PR DESCRIPTION
this is a followup to https://github.com/cloudigrade/cloudigrade/pull/882 for https://github.com/cloudigrade/cloudigrade/issues/848