### PR TITLE
use haberdasher v0.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN microdnf update \
     && microdnf clean all
 
 RUN curl -L -o /usr/bin/haberdasher \
-    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+    https://github.com/RedHatInsights/haberdasher/releases/download/v0.1.5/haberdasher_linux_amd64 && \
     chmod 755 /usr/bin/haberdasher
 
 COPY deployment/playbooks/ ./playbooks


### PR DESCRIPTION
for https://github.com/cloudigrade/cloudigrade/issues/786

Hopefully this will address some of our recent broken deployments. haberdasher 0.1.5 undoes some recent changes that might be causing our problems.