### PR TITLE
Cache value of get_sources_cloudigrade_application_type_id

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -496,3 +496,12 @@ SOURCES_AVAILABILITY_EVENT_TYPE = env(
     "SOURCES_AVAILABILITY_EVENT_TYPE",
     default="availability_status",
 )
+
+# Cache ttl settings
+CACHE_TTL_DEFAULT = env.int(
+    "CACHE_TTL_DEFAULT", default=60
+)
+
+CACHE_TTL_SOURCES_APPLICATION_TYPE_ID = env.int(
+    "CACHE_TTL_SOURCES_APPLICATION_TYPE_ID", default=CACHE_TTL_DEFAULT
+)

--- a/cloudigrade/util/redhatcloud/sources.py
+++ b/cloudigrade/util/redhatcloud/sources.py
@@ -4,6 +4,7 @@ import json
 import logging
 
 import requests
+from cache_memoize import cache_memoize
 from confluent_kafka import KafkaException, Producer as KafkaProducer
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -187,6 +188,7 @@ def extract_ids_from_kafka_message(message, headers):
     return account_number, platform_id
 
 
+@cache_memoize(60)
 def get_cloudigrade_application_type_id(account_number):
     """Get the cloudigrade application type id from sources."""
     sources_api_base_url = settings.SOURCES_API_BASE_URL

--- a/cloudigrade/util/redhatcloud/sources.py
+++ b/cloudigrade/util/redhatcloud/sources.py
@@ -188,7 +188,7 @@ def extract_ids_from_kafka_message(message, headers):
     return account_number, platform_id
 
 
-@cache_memoize(60)
+@cache_memoize(settings.CACHE_TTL_SOURCES_APPLICATION_TYPE_ID)
 def get_cloudigrade_application_type_id(account_number):
     """Get the cloudigrade application type id from sources."""
     sources_api_base_url = settings.SOURCES_API_BASE_URL

--- a/cloudigrade/util/tests/redhatcloud/test_sources.py
+++ b/cloudigrade/util/tests/redhatcloud/test_sources.py
@@ -133,6 +133,30 @@ class SourcesTest(TestCase):
         mock_get.assert_called()
 
     @patch("requests.get")
+    def test_get_sources_cloudigrade_application_type_is_cached(self, mock_get):
+        """Assert get_cloudigrade_application_type_id returns cached id."""
+        cloudigrade_app_type_id = _faker.pyint()
+        expected = {"data": [{"id": cloudigrade_app_type_id}]}
+        mock_get.return_value.status_code = http.HTTPStatus.OK
+        mock_get.return_value.json.return_value = expected
+
+        response_app_type_id = sources.get_cloudigrade_application_type_id(
+            self.account_number
+        )
+        self.assertEqual(response_app_type_id, cloudigrade_app_type_id)
+
+        """Call it again and make sure the original, cached value is returened"""
+        not_cloudigrade_app_type_id = _faker.pyint()
+        not_expected = {"data": [{"id": not_cloudigrade_app_type_id}]}
+        mock_get.return_value.json.return_value = not_expected
+
+        response_app_type_id = sources.get_cloudigrade_application_type_id(
+            self.account_number
+        )
+        self.assertEqual(response_app_type_id, cloudigrade_app_type_id)
+        mock_get.assert_called_once()
+
+    @patch("requests.get")
     def test_get_sources_cloudigrade_application_type_fail(self, mock_get):
         """Assert get_cloudigrade_application_type_id returns None."""
         mock_get.return_value.status_code = http.HTTPStatus.NOT_FOUND

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,7 +22,7 @@ ansible-base = ">=2.10.5,<2.11"
 
 [[package]]
 name = "ansible-base"
-version = "2.10.9"
+version = "2.10.10"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
@@ -124,20 +124,20 @@ python-versions = "*"
 
 [[package]]
 name = "boto3"
-version = "1.17.75"
+version = "1.17.79"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = ">=1.20.75,<1.21.0"
+botocore = ">=1.20.79,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
 [[package]]
 name = "botocore"
-version = "1.20.75"
+version = "1.20.79"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -338,6 +338,17 @@ sqlparse = ">=0.2.2"
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django-cache-memoize"
+version = "0.1.9"
+description = "Django utility for a memoization decorator that uses the Django cache framework."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["flake8", "tox", "twine", "therapist", "black"]
 
 [[package]]
 name = "django-celery-beat"
@@ -558,14 +569,14 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.0.0"
+version = "3.0.1"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-MarkupSafe = ">=2.0.0rc2"
+MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
@@ -610,17 +621,18 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 
 [[package]]
 name = "kombu"
-version = "5.0.2"
+version = "5.1.0"
 description = "Messaging library for Python."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-amqp = ">=5.0.0,<6.0.0"
+amqp = ">=5.0.6,<6.0.0"
+vine = "*"
 
 [package.extras]
-azureservicebus = ["azure-servicebus (>=0.21.1)"]
+azureservicebus = ["azure-servicebus (>=7.0.0)"]
 azurestoragequeues = ["azure-storage-queue"]
 consul = ["python-consul (>=0.6.0)"]
 librabbitmq = ["librabbitmq (>=1.5.2)"]
@@ -631,7 +643,7 @@ qpid = ["qpid-python (>=0.26)", "qpid-tools (>=0.26)"]
 redis = ["redis (>=3.3.11)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
 sqlalchemy = ["sqlalchemy"]
-sqs = ["boto3 (>=1.4.4)", "pycurl (==7.43.0.2)"]
+sqs = ["boto3 (>=1.4.4)", "pycurl (==7.43.0.2)", "urllib3 (<1.26)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=1.3.1)"]
 
@@ -1069,7 +1081,7 @@ python-versions = ">=3.5,"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "db1d2b97a911191dbf21769750f6c2d2103be12458c76c015ee0c59fde3cf4f2"
+content-hash = "65e51e41a20bef13d14e05c7eecad913572c478b8eadcc66032ce01903ce102f"
 
 [metadata.files]
 amqp = [
@@ -1080,7 +1092,7 @@ ansible = [
     {file = "ansible-2.10.7.tar.gz", hash = "sha256:9ff024500116d53c460cb09ea92e3c9404119f100d1d1ff0de69a9dafca561d5"},
 ]
 ansible-base = [
-    {file = "ansible-base-2.10.9.tar.gz", hash = "sha256:04635d3e08fc29358c76b8e7f1e9db0ce443fb09ce30b2acc6cacaad165f2151"},
+    {file = "ansible-base-2.10.10.tar.gz", hash = "sha256:7744b68ed81de948853304b8104b63651c5d6b03571aee972c83379aa6b7de10"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1111,12 +1123,12 @@ boto = [
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.17.75-py2.py3-none-any.whl", hash = "sha256:7059b3dbb6b474c6ef836aa3bb53eb7b3e474133f3e4cb2a3a3adcc55e2b2b9d"},
-    {file = "boto3-1.17.75.tar.gz", hash = "sha256:bc8b6e98375f71dde0f51e08d415a72e3d8389042ea07d216ac82c98060e7149"},
+    {file = "boto3-1.17.79-py2.py3-none-any.whl", hash = "sha256:1815748c9409e6d9a13a88a4f59c49d42c5d873a116c95ef18092ed3bd20b1c5"},
+    {file = "boto3-1.17.79.tar.gz", hash = "sha256:ccc2c2e412d31b9e542c525764c059f7523cf5268b0ce3c5b244f4df29367d9c"},
 ]
 botocore = [
-    {file = "botocore-1.20.75-py2.py3-none-any.whl", hash = "sha256:80fc9a463bcc6368ed95d4b10717f5bb87288b930b3ccf96ce480d1c65e20e5c"},
-    {file = "botocore-1.20.75.tar.gz", hash = "sha256:ab1bd5d5f86a4fdd194129a6102e5193209d3c4676dd76881769d6894bbaab7e"},
+    {file = "botocore-1.20.79-py2.py3-none-any.whl", hash = "sha256:7518c3f028123f2c770cf1e568f24877259e0ec03badef657174fa93392a9e6a"},
+    {file = "botocore-1.20.79.tar.gz", hash = "sha256:b69c96f210a79f544c6dea923f708873121c174b8b4d72babd725328bf53e3d2"},
 ]
 celery = [
     {file = "celery-5.0.5-py3-none-any.whl", hash = "sha256:5e8d364e058554e83bbb116e8377d90c79be254785f357cb2cec026e79febe13"},
@@ -1278,6 +1290,10 @@ django = [
     {file = "Django-3.2.3-py3-none-any.whl", hash = "sha256:7e0a1393d18c16b503663752a8b6790880c5084412618990ce8a81cc908b4962"},
     {file = "Django-3.2.3.tar.gz", hash = "sha256:13ac78dbfd189532cad8f383a27e58e18b3d33f80009ceb476d7fcbfc5dcebd8"},
 ]
+django-cache-memoize = [
+    {file = "django-cache-memoize-0.1.9.tar.gz", hash = "sha256:31f9d45fc1374d64963c5490877b857d3160d9b9047e40e40ed721345ca32bf3"},
+    {file = "django_cache_memoize-0.1.9-py3-none-any.whl", hash = "sha256:01b209488d3b62d2de362de82d55098f7393e36d31c6e220fa88165e3556aa28"},
+]
 django-celery-beat = [
     {file = "django-celery-beat-2.2.0.tar.gz", hash = "sha256:b8a13afb15e7c53fc04f4f847ac71a6d32088959aba701eb7c4a59f0c28ba543"},
     {file = "django_celery_beat-2.2.0-py2.py3-none-any.whl", hash = "sha256:c4c72a9579f20eff4c4ccf1b58ebdca5ef940f4210065057db1754ea5f8dffdc"},
@@ -1324,6 +1340,7 @@ flake8 = [
 ]
 flake8-black = [
     {file = "flake8-black-0.2.1.tar.gz", hash = "sha256:f26651bc10db786c03f4093414f7c9ea982ed8a244cec323c984feeffdf4c118"},
+    {file = "flake8_black-0.2.1-py3-none-any.whl", hash = "sha256:941514149cb8b489cb17a4bb1cf18d84375db3b34381bb018de83509437931a0"},
 ]
 flake8-docstrings = [
     {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
@@ -1353,8 +1370,8 @@ isort = [
     {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.0-py3-none-any.whl", hash = "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6"},
-    {file = "Jinja2-3.0.0.tar.gz", hash = "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"},
+    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
+    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
 ]
 jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
@@ -1369,8 +1386,8 @@ jsonschema = [
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
 kombu = [
-    {file = "kombu-5.0.2-py2.py3-none-any.whl", hash = "sha256:6dc509178ac4269b0e66ab4881f70a2035c33d3a622e20585f965986a5182006"},
-    {file = "kombu-5.0.2.tar.gz", hash = "sha256:f4965fba0a4718d47d470beeb5d6446e3357a62402b16c510b6a2f251e05ac3c"},
+    {file = "kombu-5.1.0-py3-none-any.whl", hash = "sha256:e2dedd8a86c9077c350555153825a31e456a0dc20c15d5751f00137ec9c75f0a"},
+    {file = "kombu-5.1.0.tar.gz", hash = "sha256:01481d99f4606f6939cdc9b637264ed353ee9e3e4f62cfb582324142c41a572d"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ confluent-kafka = "^1.6.1"
 django-prometheus = "~=2.1.0"
 django-filter = "~=2.4.0"
 prometheus_client = "~=0.10.1"
+django-cache-memoize = "~=0.1.9"
 
 [tool.poetry.dev-dependencies]
 seqdiag = "*"


### PR DESCRIPTION
Leveraging `django-cache-memoize` to implement caching the value of `get_cloudigrade_application_type_id`, since application types

rarely changes on sources, and avoids making unnecessary calls to the Sources API. The cache ttl is 60 seconds here but it could easily be much higher

for #663