### PR TITLE
reorganize clouds.aws.util.verify_permissions

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/verification.py
+++ b/cloudigrade/api/clouds/aws/tasks/verification.py
@@ -1,7 +1,7 @@
 """Celery tasks related to verifying data and customer accounts for AWS."""
 import logging
 
-from celery.task import task
+from celery import shared_task
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.utils.translation import gettext as _
@@ -16,7 +16,7 @@ from util.celery import retriable_shared_task
 logger = logging.getLogger(__name__)
 
 
-@task(name="api.clouds.aws.tasks.verify_account_permissions")
+@shared_task(name="api.clouds.aws.tasks.verify_account_permissions")
 def verify_account_permissions(account_arn):
     """
     Periodic task that verifies the account arn is still valid.

--- a/cloudigrade/api/tests/clouds/aws/test_serializers.py
+++ b/cloudigrade/api/tests/clouds/aws/test_serializers.py
@@ -188,18 +188,13 @@ class AwsAccountSerializerTest(TransactionTestCase):
             mock_assume_role.side_effect = client_error
             mock_verify.return_value = True, []
 
-            expected_error = {
-                "account_arn": ['Permission denied for ARN "{0}"'.format(self.arn)]
-            }
+            expected_error = "Could not enable"
             with self.assertLogs("api.models", level="INFO") as cm, self.assertRaises(
                 ValidationError
             ):
                 serializer.create(self.validated_data)
             log_record = cm.records[1]
-            self.assertIn(
-                expected_error["account_arn"][0],
-                log_record.msg.detail["account_arn"][0],
-            )
+            self.assertIn(expected_error, log_record.msg.detail["account_arn"])
 
     @patch("api.tasks.notify_application_availability_task")
     def test_create_fails_when_aws_verify_fails(self, mock_notify_sources):
@@ -216,16 +211,13 @@ class AwsAccountSerializerTest(TransactionTestCase):
             mock_assume_role.return_value = self.role
             mock_verify.return_value = False, []
 
-            expected_error = {"account_arn": ["Account verification failed."]}
+            expected_error = "Could not enable"
             with self.assertLogs("api.models", level="INFO") as cm, self.assertRaises(
                 ValidationError
             ):
                 serializer.create(self.validated_data)
             log_record = cm.records[1]
-            self.assertIn(
-                expected_error["account_arn"][0],
-                log_record.msg.detail["account_arn"][0],
-            )
+            self.assertIn(expected_error, log_record.msg.detail["account_arn"])
 
     @patch("api.tasks.notify_application_availability_task")
     def test_create_fails_cloudtrail_configuration_error(self, mock_notify_sources):
@@ -248,18 +240,10 @@ class AwsAccountSerializerTest(TransactionTestCase):
             mock_verify.return_value = True, []
             mock_cloudtrail.side_effect = client_error
 
-            expected_error = {
-                "account_arn": [
-                    "Access denied to create CloudTrail for "
-                    'ARN "{0}"'.format(self.arn)
-                ]
-            }
+            expected_error = "Could not enable"
             with self.assertLogs("api.models", level="INFO") as cm, self.assertRaises(
                 ValidationError
             ):
                 serializer.create(self.validated_data)
             log_record = cm.records[1]
-            self.assertIn(
-                expected_error["account_arn"][0],
-                log_record.msg.detail["account_arn"][0],
-            )
+            self.assertIn(expected_error, log_record.msg.detail["account_arn"])


### PR DESCRIPTION
reorganize clouds.aws.util.verify_permissions

- always notify sources about errors encountered here
- be more explicit about handling different exceptions
- make unit tests cover happy and all major error paths
- stop raising ValidationError since only the seldom-used internal HTTP API cares about that
- stop notifying sources in verify_account_permissions since verify_permissions would have already done that

This also includes a minor fix to an old-style deprecated `task` import that should be `shared_task`.

for https://github.com/cloudigrade/cloudigrade/issues/892

Note that I added `TODO`s in some comments about adding more error codes. I opened the following issue for that: https://github.com/cloudigrade/cloudigrade/issues/907