### PR TITLE
make watchtower configs configurable

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -106,7 +106,9 @@ if env.bool("CLOUDIGRADE_ENABLE_CLOUDWATCH", default=False):
         "log_group": env("CLOUDIGRADE_CW_LOG_GROUP"),
         "stream_name": env("CLOUDIGRADE_CW_STREAM_NAME"),
         "formatter": "verbose",
-        "use_queues": False,
+        "use_queues": env.bool("WATCHTOWER_USE_QUEUES", default=True),
+        "send_interval": env.float("WATCHTOWER_SEND_INTERVAL", default=1.0),
+        "max_batch_count": env.float("WATCHTOWER_MAX_BATCH_COUNT", default=1000),
     }
     for logger_name, logger in LOGGING["loggers"].items():
         print(f"Appending watchtower to handlers for '{logger_name}'")


### PR DESCRIPTION
for https://github.com/cloudigrade/cloudigrade/issues/906

our new defaults are:
- use_queues=True (internal watchtower default is True)
- send_interval=1.0 seconds (internal watchtower default is 60)
- max_batch_count=1000 (internal watchtower default is 10000)

---

Discussion of research follows:

Under normal conditions, individual logs appear to be sent to AWS immediately with `send_interval=0`. Under very rapid logging conditions, unfortunately, many logs may be significantly delayed before arriving in CloudWatch, presumably due to some kind of throttling or simply because the posting of messages happens serially and is just plain slow. For example, logging in this fast loop:

```
for _ in range(1000):
  logger.info(_)
```

…resulted in this attached CloudWatch content ([cloudwatch-fast1000_2.txt](https://github.com/cloudigrade/cloudigrade/files/6524255/cloudwatch-fast1000_2.txt)). Note at the end were also two separate ad-hoc logs for "hello" and "world". Processing that file to calculate the delays in milliseconds between when each log actually occurred and when it was ingested by CloudWatch:

```
cat /tmp/cloudwatch-fast1000_2.txt | jq ".events[] | .ingestionTime - .timestamp" > /tmp/delays.txt
```

…resulted in this attached file ([delays.txt](https://github.com/cloudigrade/cloudigrade/files/6524272/delays.txt)). Note that during the tight loop, the delays are gradually increasing until finally, with the ad-hoc logging a couple minutes _after_ the loop ended, the delay is back down to ~200 ms.

Since under normal conditions it seems to take about 200-300 ms on the round-trip for posting to CloudWatch, this means that by using `send_interval=0` we would likely start noticeably piling up messages _if_ a process were to _continuously produce_ 3-5 (or more) log messages per second.

To actually use the batching feature as intended, which could mitigate the aforementioned pileups, we'd want to set `send_interval` to a positive value, maybe even just one second. However, as soon as we make it nonzero, we encounter the original problem I noted long ago: if log message `n` is not the last message in a batch size or timing window, that means message `n` will wait until `n+1`, `n+2`, … when the next batch count or timer threshold is hit.

Maybe we should try with `send_interval` set to `0` for a while and observe the results. If we're seeing pileups and delays, we could adjust it upwards to a comfortable level, again with the understanding that tail-end messages might wait indefinitely to send until a new log occurs.