### PR TITLE
Include x-rh-identity in the Kafka message headers

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/aws/tasks/onboarding.py
@@ -55,14 +55,14 @@ def configure_customer_aws_and_create_cloud_account(
         error.log_internal_message(
             logger, {"application_id": application_id, "username": username}
         )
-        error.notify(application_id)
+        error.notify(username, application_id)
         return
     try:
         customer_aws_account_id = aws.AwsArn(customer_arn).account_id
     except InvalidArn:
         error = error_codes.CG1004
         error.log_internal_message(logger, {"application_id": application_id})
-        error.notify(application_id)
+        error.notify(username, application_id)
         return
 
     cloud_account_name = get_standard_cloud_account_name("aws", customer_aws_account_id)

--- a/cloudigrade/api/error_codes.py
+++ b/cloudigrade/api/error_codes.py
@@ -29,13 +29,14 @@ class CloudigradeError:
         """Get the external message for an error."""
         return self.message % {"error_code": self.code}
 
-    def notify(self, application_id, error_message=None):
+    def notify(self, account_number, application_id, error_message=None):
         """Tell sources an application is not available because of error."""
         from api.tasks import notify_application_availability_task
 
         if not error_message:
             error_message = self.get_message()
         notify_application_availability_task.delay(
+            account_number,
             application_id,
             availability_status="unavailable",
             availability_status_error=error_message,

--- a/cloudigrade/api/models.py
+++ b/cloudigrade/api/models.py
@@ -136,7 +136,7 @@ class CloudAccount(ExportModelOperationsMixin("CloudAccount"), BaseGenericModel)
         from api.tasks import notify_application_availability_task
 
         notify_application_availability_task.delay(
-            self.platform_application_id, "available"
+            self.user.username, self.platform_application_id, "available"
         )
 
     @transaction.atomic
@@ -170,7 +170,7 @@ class CloudAccount(ExportModelOperationsMixin("CloudAccount"), BaseGenericModel)
             from api.tasks import notify_application_availability_task
 
             notify_application_availability_task.delay(
-                self.platform_application_id, "unavailable", message
+                self.user.username, self.platform_application_id, "unavailable", message
             )
         logger.info(_("Finished disabling %(account)s"), {"account": self})
 

--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -131,7 +131,7 @@ def create_from_sources_kafka_message(message, headers):
             logger,
             {"authentication_id": authentication_id, "account_number": account_number},
         )
-        error_code.notify(application_id)
+        error_code.notify(account_number, application_id)
         return
 
     authtype = authentication.get("authtype")
@@ -140,7 +140,7 @@ def create_from_sources_kafka_message(message, headers):
         error_code.log_internal_message(
             logger, {"authentication_id": authentication_id, "authtype": authtype}
         )
-        error_code.notify(application_id)
+        error_code.notify(account_number, application_id)
         return
 
     resource_type = authentication.get("resource_type")
@@ -150,7 +150,7 @@ def create_from_sources_kafka_message(message, headers):
         error_code.log_internal_message(
             logger, {"resource_id": resource_id, "account_number": account_number}
         )
-        error_code.notify(application_id)
+        error_code.notify(account_number, application_id)
         return
 
     source_id = application.get("source_id")
@@ -161,7 +161,7 @@ def create_from_sources_kafka_message(message, headers):
         error_code.log_internal_message(
             logger, {"authentication_id": authentication_id}
         )
-        error_code.notify(application_id)
+        error_code.notify(account_number, application_id)
         return
 
     with transaction.atomic():
@@ -376,7 +376,7 @@ def update_from_source_kafka_message(message, headers):
             error_code.log_internal_message(
                 logger, {"authentication_id": authentication_id}
             )
-            error_code.notify(application_id)
+            error_code.notify(account_number, application_id)
             return
 
         # If the Authentication being updated is arn, do arn things.
@@ -728,7 +728,7 @@ def enable_account(cloud_account_id):
     name="api.tasks.notify_application_availability_task",
 )
 def notify_application_availability_task(
-    application_id, availability_status, availability_status_error=""
+    account_number, application_id, availability_status, availability_status_error=""
 ):
     """
     Update Sources application's availability status.
@@ -737,13 +737,17 @@ def notify_application_availability_task(
     method which sends the availability_status Kafka message to Sources.
 
     Args:
+        account_number (str): Account number identifier
         application_id (int): Platform insights application id
         availability_status (string): Availability status to set
         availability_status_error (string): Optional status error
     """
     try:
         sources.notify_application_availability(
-            application_id, availability_status, availability_status_error
+            account_number,
+            application_id,
+            availability_status,
+            availability_status_error,
         )
     except KafkaProducerException:
         raise

--- a/cloudigrade/api/tests/tasks/test_notify_application_availability_task.py
+++ b/cloudigrade/api/tests/tasks/test_notify_application_availability_task.py
@@ -15,13 +15,18 @@ class NotifyApplicationAvailabilityTaskTest(TestCase):
 
     def setUp(self):
         """Set up shared variables."""
+        self.account_number = str(_faker.pyint())
         self.application_id = _faker.pyint()
 
     @patch("util.redhatcloud.sources.notify_application_availability")
     def test_notify_application_availability_task_success(self, mock_notify_sources):
         """Assert notify_application_availability with available message success."""
-        notify_application_availability_task(self.application_id, "available", "")
-        mock_notify_sources.assert_called_with(self.application_id, "available", "")
+        notify_application_availability_task(
+            self.account_number, self.application_id, "available", ""
+        )
+        mock_notify_sources.assert_called_with(
+            self.account_number, self.application_id, "available", ""
+        )
 
     @patch("util.redhatcloud.sources.notify_application_availability")
     def test_notify_application_availability_task_with_error_success(
@@ -29,10 +34,10 @@ class NotifyApplicationAvailabilityTaskTest(TestCase):
     ):
         """Assert notify_application_availability with unavailable message success."""
         notify_application_availability_task(
-            self.application_id, "unavailable", "bad_error"
+            self.account_number, self.application_id, "unavailable", "bad_error"
         )
         mock_notify_sources.assert_called_with(
-            self.application_id, "unavailable", "bad_error"
+            self.account_number, self.application_id, "unavailable", "bad_error"
         )
 
     @patch("util.redhatcloud.sources.notify_application_availability")
@@ -42,5 +47,9 @@ class NotifyApplicationAvailabilityTaskTest(TestCase):
         """Assert notify_application_availability with available message exception."""
         mock_notify_sources.side_effect = KafkaProducerException("network error")
         with self.assertRaises(KafkaProducerException):
-            notify_application_availability_task(self.application_id, "available", "")
-        mock_notify_sources.assert_called_with(self.application_id, "available", "")
+            notify_application_availability_task(
+                self.account_number, self.application_id, "available", ""
+            )
+        mock_notify_sources.assert_called_with(
+            self.account_number, self.application_id, "available", ""
+        )

--- a/cloudigrade/api/tests/test_error_codes.py
+++ b/cloudigrade/api/tests/test_error_codes.py
@@ -44,9 +44,11 @@ class ErrorCodeTestCase(TestCase):
     @patch("api.tasks.notify_application_availability_task")
     def test_notify_sources(self, mock_notify_sources):
         """Test that notify calls notify_application_availability."""
+        account_number = str(_faker.pyint())
         app_id = _faker.pyint()
-        self.custom_error.notify(app_id)
+        self.custom_error.notify(account_number, app_id)
         mock_notify_sources.delay.assert_called_once_with(
+            account_number,
             app_id,
             availability_status="unavailable",
             availability_status_error="Message including {}".format(self.error_code),

--- a/cloudigrade/util/redhatcloud/sources.py
+++ b/cloudigrade/util/redhatcloud/sources.py
@@ -206,7 +206,7 @@ def get_cloudigrade_application_type_id(account_number):
 
 
 def notify_application_availability(
-    application_id, availability_status, availability_status_error=""
+    account_number, application_id, availability_status, availability_status_error=""
 ):
     """
     Update Sources application's availability status.
@@ -215,6 +215,7 @@ def notify_application_availability(
     receiving the availability_status update request Kafka message.
 
     Args:
+        account_number (str): Account number identifier
         application_id (int): Platform insights application id
         availability_status (string): Availability status to set
         availability_status_error (string): Optional status error
@@ -253,9 +254,15 @@ def notify_application_availability(
             )
         kafka_producer = KafkaProducer(sources_kafka_config)
 
+        headers = identity.generate_http_identity_headers(
+            account_number, is_org_admin=True
+        )
         message_topic = settings.SOURCES_STATUS_TOPIC
         message_value = json.dumps(payload)
-        message_headers = {"event_type": settings.SOURCES_AVAILABILITY_EVENT_TYPE}
+        message_headers = {
+            "x-rh-identity": headers["X-RH-IDENTITY"],
+            "event_type": settings.SOURCES_AVAILABILITY_EVENT_TYPE,
+        }
 
         if settings.VERBOSE_SOURCES_NOTIFICATION_LOGGING:
             logger.info(


### PR DESCRIPTION
for https://github.com/cloudigrade/cloudigrade/issues/919

Updated the Sources availability notification via Kafka to include the x-rh-identity in the kafka message header.

Marking as WIP:
- [x] review code
- [x] test against sources
