### PR TITLE
also log CACHE_TTL_DEFAULT and CACHE_TTL_SOURCES_APPLICATION_TYPE_ID at startup

### DIFF
--- a/cloudigrade/api/apps.py
+++ b/cloudigrade/api/apps.py
@@ -8,6 +8,8 @@ logger = logging.getLogger(__name__)
 
 # A list of application settings that we want logged on app startup
 APPLICATION_SETTINGS_TO_LOG = [
+    "CACHE_TTL_DEFAULT",
+    "CACHE_TTL_SOURCES_APPLICATION_TYPE_ID",
     "CLOUDIGRADE_ENVIRONMENT",
     "CLOUDIGRADE_VERSION",
     "DEBUG",


### PR DESCRIPTION
for https://github.com/cloudigrade/cloudigrade/issues/663