### PR TITLE
- Updated the concurrent API so we allow the end_date to be  the same as the user creation date.

### DIFF
--- a/cloudigrade/api/views.py
+++ b/cloudigrade/api/views.py
@@ -115,7 +115,7 @@ class DailyConcurrentUsageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin
 
     def early_end_date_error(self):
         """Return the error message for specifying an early end_date."""
-        return _("end_date must be after user creation date.")
+        return _("end_date must be same as or after the user creation date.")
 
     def late_end_date_error(self):
         """Return the error message for specifying a late end_date."""
@@ -148,7 +148,7 @@ class DailyConcurrentUsageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin
             # If end date is after tomorrow, we do not return anything
             if end_date > self.latest_end_date():
                 errors["end_date"] = [self.late_end_date_error()]
-            if end_date <= user.date_joined.date():
+            if end_date < user.date_joined.date():
                 errors["end_date"] = [self.early_end_date_error()]
         except ValueError:
             errors["end_date"] = [self.invalid_end_date_error()]

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -2149,7 +2149,7 @@ Response:
 
     HTTP/1.1 400 Bad Request
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 59
+    Content-Length: 74
     Content-Type: application/json
     Referrer-Policy: same-origin
     Vary: Accept
@@ -2159,7 +2159,7 @@ Response:
 
     {
         "end_date": [
-            "end_date must be after user creation date."
+            "end_date must be same as or after the user creation date."
         ]
     }
 


### PR DESCRIPTION
- Updated the concurrent API so we allow the end_date to be  the same as the user creation date.