### PR TITLE
code cleanup (process_instance_event is not a task, normalized→denormalized)

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -24,6 +24,7 @@ from api.models import (
     MachineImage,
     MachineImageInspectionStart,
 )
+from api.util import process_instance_event
 from util import aws
 from util.exceptions import (
     InvalidArn,
@@ -361,8 +362,6 @@ def save_instance_events(awsinstance, instance_data, events=None):
         AwsInstance: Object representing the saved instance.
 
     """
-    from api.tasks import process_instance_event  # local import to avoid loop
-
     if events is None:
         with transaction.atomic():
             occurred_at = get_now()
@@ -467,8 +466,6 @@ def create_missing_power_off_aws_instance_events(account, instances_data):
     this, we risk letting dead instances with never-ending runs contribute erroneously
     to concurrent usage calculations for new days.
     """
-    from api.tasks import process_instance_event  # local import to avoid loop
-
     # Build a list of currently-running instance IDs according to the described data.
     running_ec2_instance_ids = set()
     for region, instances in instances_data.items():

--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -413,8 +413,6 @@ def update_from_source_kafka_message(message, headers):
             )
 
 
-@shared_task(name="api.tasks.process_instance_event")
-@transaction.atomic
 def process_instance_event(event):
     """
     Process instance events that have been saved during log analysis.

--- a/cloudigrade/api/tests/clouds/aws/tasks/onboarding/test_initial_aws_describe_instances.py
+++ b/cloudigrade/api/tests/clouds/aws/tasks/onboarding/test_initial_aws_describe_instances.py
@@ -13,8 +13,8 @@ from api.models import (
     MachineImage,
     Run,
 )
-from api.tasks import process_instance_event
 from api.tests import helper as account_helper
+from api.util import process_instance_event
 from util.tests import helper as util_helper
 
 
@@ -204,7 +204,7 @@ class InitialAwsDescribeInstancesPowerOffNotRunningTest(TestCase):
     def process_event(self, event):
         """Process the event but skip the async calculate max concurrent function."""
         with patch(
-            "api.tasks.calculate_max_concurrent_usage_from_runs"
+            "api.util.calculate_max_concurrent_usage_from_runs"
         ) as mock_calculate_max_concurrent:
             process_instance_event(event)
             if event.event_type == InstanceEvent.TYPE.power_on:

--- a/cloudigrade/api/tests/util/test_denormalize_runs.py
+++ b/cloudigrade/api/tests/util/test_denormalize_runs.py
@@ -1,4 +1,4 @@
-"""Collection of tests for api.util.normalize_runs."""
+"""Collection of tests for api.util.denormalize_runs."""
 import random
 
 import faker
@@ -11,8 +11,8 @@ from util.tests import helper as util_helper
 _faker = faker.Faker()
 
 
-class NormalizeRunsTest(TestCase):
-    """Test cases for api.util.normalize_runs."""
+class DenormalizeRunsTest(TestCase):
+    """Test cases for api.util.denormalize_runs."""
 
     def setUp(self):
         """Set up commonly used data for each test."""
@@ -47,8 +47,8 @@ class NormalizeRunsTest(TestCase):
 
         api_helper.generate_instance_type_definitions()
 
-    def test_normalize_instance_on_off(self):
-        """Test normalize_runs for one plain instance."""
+    def test_denormalize_instance_on_off(self):
+        """Test denormalize_runs for one plain instance."""
         powered_times = (
             (
                 util_helper.utc_dt(2019, 1, 9, 0, 0, 0),
@@ -56,7 +56,7 @@ class NormalizeRunsTest(TestCase):
             ),
         )
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 1)
         run = runs[0]
         self.assertEquals(run.start_time, powered_times[0][0])
@@ -77,11 +77,11 @@ class NormalizeRunsTest(TestCase):
         self.assertFalse(run.openshift)
         self.assertFalse(run.openshift_detected)
 
-    def test_normalize_instance_on_never_off(self):
-        """Test normalize_runs for an instance that starts but never stops."""
+    def test_denormalize_instance_on_never_off(self):
+        """Test denormalize_runs for an instance that starts but never stops."""
         powered_times = ((util_helper.utc_dt(2019, 1, 9, 0, 0, 0), None),)
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 1)
         run = runs[0]
         self.assertEquals(run.start_time, powered_times[0][0])
@@ -89,8 +89,8 @@ class NormalizeRunsTest(TestCase):
         self.assertEquals(run.instance_id, self.instance_plain.id)
         self.assertEquals(run.image_id, self.image_plain.id)
 
-    def test_normalize_multiple_instances_on_off(self):
-        """Test normalize_runs for events for multiple instances and images."""
+    def test_denormalize_multiple_instances_on_off(self):
+        """Test denormalize_runs for events for multiple instances and images."""
         rhel_powered_times = (
             (
                 util_helper.utc_dt(2019, 1, 9, 0, 0, 0),
@@ -114,7 +114,7 @@ class NormalizeRunsTest(TestCase):
         events = rhel_events[:-1] + ocp_events[::-1] + rhel_events[-1:]
         random.shuffle(events)
 
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 2)
 
         rhel_run = runs[0] if runs[0].rhel else runs[1]
@@ -134,8 +134,8 @@ class NormalizeRunsTest(TestCase):
         self.assertEquals(ocp_run.instance_id, self.instance_ocp.id)
         self.assertEquals(ocp_run.image_id, self.image_ocp.id)
 
-    def test_normalize_one_instance_multiple_on_off(self):
-        """Test normalize_runs one instance having multiple on-off cycles."""
+    def test_denormalize_one_instance_multiple_on_off(self):
+        """Test denormalize_runs one instance having multiple on-off cycles."""
         powered_times = (
             (
                 util_helper.utc_dt(2019, 1, 9, 0, 0, 0),
@@ -150,7 +150,7 @@ class NormalizeRunsTest(TestCase):
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
         random.shuffle(events)
 
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), len(powered_times))
         sorted_runs = sorted(runs, key=lambda r: r.start_time)
         for index, run in enumerate(sorted_runs):
@@ -159,9 +159,9 @@ class NormalizeRunsTest(TestCase):
             self.assertEquals(run.instance_id, self.instance_plain.id)
             self.assertEquals(run.image_id, self.image_plain.id)
 
-    def test_normalize_one_instance_on_on_on_off(self):
+    def test_denormalize_one_instance_on_on_on_off(self):
         """
-        Test normalize_runs one instance with multiple on and one off.
+        Test denormalize_runs one instance with multiple on and one off.
 
         In this special case, only one run should be created. The first on
         event is the only one relevant to that run.
@@ -177,7 +177,7 @@ class NormalizeRunsTest(TestCase):
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
         random.shuffle(events)
 
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 1)
         run = runs[0]
         self.assertEquals(run.start_time, powered_times[0][0])
@@ -185,9 +185,9 @@ class NormalizeRunsTest(TestCase):
         self.assertEquals(run.instance_id, self.instance_plain.id)
         self.assertEquals(run.image_id, self.image_plain.id)
 
-    def test_normalize_one_instance_on_off_off_off(self):
+    def test_denormalize_one_instance_on_off_off_off(self):
         """
-        Test normalize_runs one instance with multiple on and one off.
+        Test denormalize_runs one instance with multiple on and one off.
 
         In this special case, only one run should be created. The first off
         event is the only one relevant to that run.
@@ -203,7 +203,7 @@ class NormalizeRunsTest(TestCase):
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
         random.shuffle(events)
 
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 1)
         run = runs[0]
         self.assertEquals(run.start_time, powered_times[0][0])
@@ -211,9 +211,9 @@ class NormalizeRunsTest(TestCase):
         self.assertEquals(run.instance_id, self.instance_plain.id)
         self.assertEquals(run.image_id, self.image_plain.id)
 
-    def test_normalize_one_instance_on_on_off_off(self):
+    def test_denormalize_one_instance_on_on_off_off(self):
         """
-        Test normalize_runs one instance with "overlapping" ons and offs.
+        Test denormalize_runs one instance with "overlapping" ons and offs.
 
         In this special case, the mock data simulates receiving information
         that would indicate two potentially overlapping runs. However, since
@@ -232,7 +232,7 @@ class NormalizeRunsTest(TestCase):
         events = api_helper.generate_instance_events(self.instance_plain, powered_times)
         random.shuffle(events)
 
-        runs = util.normalize_runs(events)
+        runs = util.denormalize_runs(events)
         self.assertEquals(len(runs), 1)
         run = runs[0]
         self.assertEquals(run.start_time, powered_times[0][0])

--- a/cloudigrade/api/util.py
+++ b/cloudigrade/api/util.py
@@ -726,3 +726,48 @@ def get_last_scheduled_concurrent_usage_calculation_task(user_id, date):
             user__id=user_id, date=date
         ).latest("created_at")
     return None
+
+
+def process_instance_event(event):
+    """
+    Process instance events that have been saved during log analysis.
+
+    Note:
+        When processing power_on type events, this triggers a recalculation of
+        ConcurrentUsage objects. If the event is at some point in the
+        not-too-recent past, this may take a while as every day since the event
+        will get recalculated and saved. We do not anticipate this being a real
+        problem in practice, but this has the potential to slow down unit test
+        execution over time since their occurred_at values are often static and
+        will recede father into the past from "today", resulting in more days
+        needing to recalculate. This effect could be mitigated in tests by
+        patching parts of the datetime module that are used to find "today".
+    """
+    after_run = Q(start_time__gt=event.occurred_at)
+    during_run = Q(start_time__lte=event.occurred_at, end_time__gt=event.occurred_at)
+    during_run_no_end = Q(start_time__lte=event.occurred_at, end_time=None)
+
+    filters = after_run | during_run | during_run_no_end
+    instance = Instance.objects.get(id=event.instance_id)
+
+    if Run.objects.filter(filters, instance=instance).exists():
+        recalculate_runs(event)
+    elif event.event_type == InstanceEvent.TYPE.power_on:
+        normalized_runs = normalize_runs([event])
+        runs = []
+        for index, normalized_run in enumerate(normalized_runs):
+            logger.info(
+                "Processing run {} of {}".format(index + 1, len(normalized_runs))
+            )
+            run = Run(
+                start_time=normalized_run.start_time,
+                end_time=normalized_run.end_time,
+                machineimage_id=normalized_run.image_id,
+                instance_id=normalized_run.instance_id,
+                instance_type=normalized_run.instance_type,
+                memory=normalized_run.instance_memory,
+                vcpu=normalized_run.instance_vcpu,
+            )
+            run.save()
+            runs.append(run)
+        calculate_max_concurrent_usage_from_runs(runs)

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -428,7 +428,6 @@ CELERY_TASK_ROUTES = {
     "api.tasks.persist_inspection_cluster_results_task": {
         "queue": "persist_inspection_cluster_results_task"
     },
-    "api.tasks.process_instance_event": {"queue": "process_instance_event"},
     # api.clouds.aws.tasks
     "api.clouds.aws.tasks.repopulate_ec2_instance_mapping": {
         "queue": "repopulate_ec2_instance_mapping"

--- a/cloudigrade/config/settings/test.py
+++ b/cloudigrade/config/settings/test.py
@@ -11,9 +11,6 @@ DATABASES = {
         "NAME": str(ROOT_DIR.path("db.sqlite3")),
     }
 }
-AWS_NAME_PREFIX = env("AWS_NAME_PREFIX", default="cloudigrade-")
-CELERY_BROKER_TRANSPORT_OPTIONS["queue_name_prefix"] = AWS_NAME_PREFIX
-CLOUDTRAIL_NAME_PREFIX = AWS_NAME_PREFIX
 
 LOGGING["handlers"]["console"]["level"] = "CRITICAL"
 logging.config.dictConfig(LOGGING)

--- a/cloudigrade/util/exceptions.py
+++ b/cloudigrade/util/exceptions.py
@@ -106,8 +106,8 @@ class AwsThrottlingException(Exception):
 
 
 # API Exceptions
-class NormalizeRunException(APIException):
-    """Raise when something unexpected happens in building NormalizeRuns."""
+class DemormalizedRunException(APIException):
+    """Raise when something unexpected happens in building DenormalizedRuns."""
 
     status_code = http.HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/cloudigrade/util/exceptions.py
+++ b/cloudigrade/util/exceptions.py
@@ -106,12 +106,6 @@ class AwsThrottlingException(Exception):
 
 
 # API Exceptions
-class DemormalizedRunException(APIException):
-    """Raise when something unexpected happens in building DenormalizedRuns."""
-
-    status_code = http.HTTPStatus.INTERNAL_SERVER_ERROR
-
-
 class NotImplementedAPIException(APIException):
     """Raise when we encounter NotImplementedError."""
 

--- a/cloudigrade/util/management/commands/create_runs.py
+++ b/cloudigrade/util/management/commands/create_runs.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from tqdm import tqdm
 
 from api.models import ConcurrentUsage, Instance, InstanceEvent, Run
-from api.util import calculate_max_concurrent_usage_from_runs, normalize_runs
+from api.util import calculate_max_concurrent_usage_from_runs, denormalize_runs
 
 logger = logging.getLogger(__name__)
 
@@ -59,17 +59,17 @@ class Command(BaseCommand):
         for instance in tqdm(Instance.objects.all(), desc="Runs for instances"):
             events = InstanceEvent.objects.filter(instance=instance)
 
-            normalized_runs = normalize_runs(events)
+            denormalized_runs = denormalize_runs(events)
 
-            for normalized_run in normalized_runs:
+            for denormalized_run in denormalized_runs:
                 run = Run(
-                    start_time=normalized_run.start_time,
-                    end_time=normalized_run.end_time,
-                    machineimage_id=normalized_run.image_id,
-                    instance_id=normalized_run.instance_id,
-                    instance_type=normalized_run.instance_type,
-                    memory=normalized_run.instance_memory,
-                    vcpu=normalized_run.instance_vcpu,
+                    start_time=denormalized_run.start_time,
+                    end_time=denormalized_run.end_time,
+                    machineimage_id=denormalized_run.image_id,
+                    instance_id=denormalized_run.instance_id,
+                    instance_type=denormalized_run.instance_type,
+                    memory=denormalized_run.instance_memory,
+                    vcpu=denormalized_run.instance_vcpu,
                 )
                 run.save()
                 runs.append(run)

--- a/docs/rest-api-examples.py
+++ b/docs/rest-api-examples.py
@@ -36,7 +36,7 @@ from django.conf import settings
 
 from api import models
 from api.tests import helper as api_helper
-from api.util import calculate_max_concurrent_usage, normalize_runs
+from api.util import calculate_max_concurrent_usage, denormalize_runs
 from util import filters
 from util.misc import get_now
 from util.tests import helper as util_helper
@@ -156,16 +156,16 @@ class DocsApiHandler(object):
         # Note: this crude and *direct* implementation of Run-saving should be
         # replaced as we continue porting pilot functionality and (eventually)
         # better general-purpose Run-handling functions materialize.
-        normalized_runs = normalize_runs(models.InstanceEvent.objects.all())
-        for normalized_run in normalized_runs:
+        denormalized_runs = denormalize_runs(models.InstanceEvent.objects.all())
+        for denormalized_run in denormalized_runs:
             run = models.Run(
-                start_time=normalized_run.start_time,
-                end_time=normalized_run.end_time,
-                machineimage_id=normalized_run.image_id,
-                instance_id=normalized_run.instance_id,
-                instance_type=normalized_run.instance_type,
-                memory=normalized_run.instance_memory,
-                vcpu=normalized_run.instance_vcpu,
+                start_time=denormalized_run.start_time,
+                end_time=denormalized_run.end_time,
+                machineimage_id=denormalized_run.image_id,
+                instance_id=denormalized_run.instance_id,
+                instance_type=denormalized_run.instance_type,
+                memory=denormalized_run.instance_memory,
+                vcpu=denormalized_run.instance_vcpu,
             )
             run.save()
 


### PR DESCRIPTION
As I work on the new internal support to allow us to identify and fix problematic Run objects that are missing their end_time values, I have accumulated some code cleanup commits that I'd like to merge before my big functional change. The net effect of _this_ PR should be nothing aside from internal code cleanup and reduced slightly tech debt. These commits include:

- remove redundant/unnecessary test settings
- remove task decorator from 'process_instance_event' since we never async call it as a task
- move process_instance_event from api.tasks to api.utils
- we are building runs in denormalized form, not normalized
- remove unused DemormalizedRunException (formerly NormalizeRunException)

Among these commits, the two big changes:

- Moving `process_instance_event` is the result of a recent discussion when we collectively realized that `process_instance_event` is never called as an async task.
- Renaming everything related to "normalized runs" to "denormalized runs" is something I've been meaning to do and has been bothering me for a long time. When we first implemented these objects and functions, we _mistakenly_ called the data "normalized". The opposite is actually true. The _normal form_ of this data consists of the underlying instances and events. The _denormalized_ form is this duplicated construct we create for performant lookups.