### PR TITLE
import task package paths excplicity for celery

### DIFF
--- a/cloudigrade/config/celery.py
+++ b/cloudigrade/config/celery.py
@@ -63,7 +63,8 @@ app.conf.beat_schedule = {
         ),
     },
 }
-app.autodiscover_tasks()
+task_packages = ["api.clouds.aws.tasks", "api.clouds.azure.tasks", "api.tasks"]
+app.autodiscover_tasks(task_packages)
 logger.info("Celery setup.")
 
 if env("CELERY_ENABLE_SENTRY", default=False):


### PR DESCRIPTION
fix celery worker problems following the addition of new tasks in https://github.com/cloudigrade/cloudigrade/pull/937 for https://github.com/cloudigrade/cloudigrade/issues/729

celery docs: https://docs.celeryproject.org/en/stable/reference/celery.html#celery.Celery.autodiscover_tasks

I think we didn't need this before because until now all of our tasks were implicitly loaded at startup because of our tangled web of imports. However, the new task in https://github.com/cloudigrade/cloudigrade/pull/937 does not currently get imported anywhere else in our app. So, Celery never sees it "for free".