### PR TITLE
set custom CELERY_ACCEPT_CONTENT to allow pickle

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -411,6 +411,7 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     "region": AWS_SQS_REGION,
 }
 CELERY_BROKER_URL = AWS_SQS_URL
+CELERY_ACCEPT_CONTENT = ["json", "pickle"]
 
 
 #####################################################################


### PR DESCRIPTION
as required for the recently pickled calls to `recalculate_concurrent_usage_for_user_id_on_date` and `recalculate_concurrent_usage_for_user_id` added in https://github.com/cloudigrade/cloudigrade/pull/951 for https://github.com/cloudigrade/cloudigrade/issues/948