### PR TITLE
fix incorrect task name on recalculate_runs_for_all_cloud_accounts

### DIFF
--- a/cloudigrade/api/tasks.py
+++ b/cloudigrade/api/tasks.py
@@ -685,7 +685,7 @@ def recalculate_runs_for_cloud_account_id(cloud_account_id):
     _recalculate_runs_for_cloud_account_id(cloud_account_id)
 
 
-@shared_task(name="api.tasks.recalculate_runs_for_all_users")
+@shared_task(name="api.tasks.recalculate_runs_for_all_cloud_accounts")
 def recalculate_runs_for_all_cloud_accounts():
     """Recalculate recent runs for all cloud accounts."""
     cloud_accounts = CloudAccount.objects.all()


### PR DESCRIPTION
this was incorrectly defined in https://github.com/cloudigrade/cloudigrade/pull/951

related to https://github.com/cloudigrade/cloudigrade/issues/948