### PR TITLE
create internal API to read and partially update PeriodicTask

### DIFF
--- a/cloudigrade/config/celery.py
+++ b/cloudigrade/config/celery.py
@@ -126,16 +126,18 @@ def cleanup_request_id(**kwargs):
     local.request_id = None
 
 
-@signals.setup_logging.connect
-def on_celery_setup_logging(**kwargs):
-    """
-    Stop celery from overriding default logging setup.
+if env.bool("CELERY_DISABLE_LOGGING_HIJACK", default=True):
 
-    By default celery hijacks the root logger. The configuration setting
-    CELERYD_HIJACK_ROOT_LOGGER only stops celery from updating the handler,
-    celery still updates the formatter and we lose the filter.
+    @signals.setup_logging.connect
+    def on_celery_setup_logging(**kwargs):
+        """
+        Stop celery from overriding default logging setup.
 
-    Since the formatter we want to use is the configured Django one,
-    we can just configure celery to not touch logging.
-    """
-    pass
+        By default celery hijacks the root logger. The configuration setting
+        CELERYD_HIJACK_ROOT_LOGGER only stops celery from updating the handler,
+        celery still updates the formatter and we lose the filter.
+
+        Since the formatter we want to use is the configured Django one,
+        we can just configure celery to not touch logging.
+        """
+        pass

--- a/cloudigrade/internal/urls.py
+++ b/cloudigrade/internal/urls.py
@@ -19,6 +19,7 @@ routes += [
 # "None" for the third tuple value means to use the model's name.
 routes += [
     ("users", views.InternalUserViewSet, "user"),
+    ("periodictasks", views.InternalPeriodicTaskViewSet, None),
     ("usertasklocks", views.InternalUserTaskLockViewSet, None),
     ("cloudaccounts", views.InternalCloudAccountViewSet, None),
     ("instances", views.InternalInstanceViewSet, None),

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -7,6 +7,7 @@ from dateutil.parser import parse
 from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.utils.translation import gettext as _
+from django_celery_beat.models import PeriodicTask
 from django_filters import rest_framework as django_filters
 from rest_framework import exceptions, mixins, permissions, status, viewsets
 from rest_framework.decorators import (
@@ -681,3 +682,13 @@ class InternalDailyConcurrentUsageViewSet(DailyConcurrentUsageViewSet):
     def late_start_date_error(self):
         """Return the error message for specifying a late start_date."""
         return _("start_date cannot be in the future.")
+
+
+@schema(None)
+class InternalPeriodicTaskViewSet(
+    InternalViewSetMixin, mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSet
+):
+    """Retrieve, update, or list PeriodicTasks for internal use."""
+
+    queryset = PeriodicTask.objects.all()
+    serializer_class = serializers.InternalPeriodicTaskSerializer


### PR DESCRIPTION
demo: https://asciinema.org/a/429695

When updating a `PeriodicTask` instance through the API, all fields besides `last_run_at` are read-only.

When any `PeriodicTask` changes through the normal Djagno model (like with this new API), a signal updates `PeriodicTasks.last_update` (note the `s` in that name) automatically with the current time. When Celery's beat ticks every second or so, it compares the current `PeriodicTasks.last_update` with its previously known value, and if there is a change, beat reloads its in-memory representation of the tasks. So, we should be able to use this to indirectly refresh the beat when we suspect it may be out of date, such as with the recent addition of new tasks for recalculating runs and concurrent usage.

There's an additional commit here adding a `CELERY_DISABLE_LOGGING_HIJACK` check so you can preserve the noisy Celery log output when running locally. Otherwise no amount of `DEBUG` settings will make Celery's logs truly verbose.