### PR TITLE
force bonfire to deploy "latest" tag for cloudigrade and postigrade

### DIFF
--- a/deployment/playbooks/roles/clowder/tasks/clowder.yml
+++ b/deployment/playbooks/roles/clowder/tasks/clowder.yml
@@ -44,6 +44,8 @@
         --timeout 600 \
         --import-secrets \
         --secrets-dir "{{ clowder_tmp_dir.path }}/secrets" \
+        --set-parameter "cloudigrade/IMAGE_TAG=latest" \
+        --set-parameter "postigrade/IMAGE_TAG=latest"  \
         --set-parameter "cloudigrade/CLOUDIGRADE_ENVIRONMENT={{ env }}" \
         --set-parameter "cloudigrade/DJANGO_SETTINGS_MODULE=config.settings.prod" \
         --set-parameter "cloudigrade/DJANGO_ALL_LOG_LEVEL=DEBUG" \


### PR DESCRIPTION
This works around an issue where by default bonfire/clowder wants to deploy with a tag containing a truncated hash like `4c59479` but an image with that tag doesn't actually exist in quay.io.