### PR TITLE
Update readme and clowder playbook to use podman.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Running **cloudigrade** locally may require installing some or all of the follow
 -  Python 3.9
 -  `poetry <https://python-poetry.org/docs/>`_
 -  `tox <https://tox.readthedocs.io/>`_
--  `Docker Desktop <https://docs.docker.com/get-docker/>`_
+-  `Podman <https://podman.io/>`_
 -  `gettext <https://www.gnu.org/software/gettext/>`_
 -  `PostgreSQL <https://www.postgresql.org/download/>`_
 -  `AWS Command Line Interface <https://aws.amazon.com/cli/>`_
@@ -41,7 +41,20 @@ The following commands should install everything you need:
 .. code-block:: bash
 
     brew update
-    brew install python@3.9 gettext awscli azure-cli postgresql openssl curl librdkafka tox poetry
+    brew install python@3.9 gettext awscli azure-cli postgresql openssl curl librdkafka tox poetry podman
+
+To start the podman machine that will be running the commands run:
+
+.. code-block:: bash
+
+    podman machine init
+    podman machine start
+
+    # you can check the status by running
+    podman info
+
+
+New to podman? Fortunately if you're already familiar with docker, the following rule is true: ``alias docker=podman``
 
 
 Linux dependencies
@@ -51,7 +64,7 @@ We recommend developing on the latest version of Fedora. Follow the following co
 
 .. code-block:: bash
 
-    sudo dnf install awscli gettext postgresql-devel librdkafka-devel -y
+    sudo dnf install awscli gettext postgresql-devel librdkafka-devel podman -y
 
 
 Python 3.9.x

--- a/deployment/playbooks/roles/clowder/tasks/push_local.yml
+++ b/deployment/playbooks/roles/clowder/tasks/push_local.yml
@@ -10,25 +10,25 @@
   - debug: var=new_image_tag.stdout
 
   - name: create / build cloudigrade
-    shell: docker build . --tag quay.io/{{ quay_user }}/cloudigrade:{{ new_image_tag.stdout }}
+    shell: podman build . --tag quay.io/{{ quay_user }}/cloudigrade:{{ new_image_tag.stdout }}
     args:
       chdir: "{{ cloudigrade_deployment_repo }}"
     when: cloudigrade_deployment_host == 'local'
 
   - name: create / build postigrade
-    shell: docker build . --tag quay.io/{{ quay_user }}/postigrade:{{ new_image_tag.stdout }}
+    shell: podman build . --tag quay.io/{{ quay_user }}/postigrade:{{ new_image_tag.stdout }}
     args:
       chdir: "{{ postigrade_deployment_repo }}"
     when: postigrade_deployment_host == 'local'
 
   - name: create / push cloudigrade
-    shell: docker push quay.io/{{ quay_user }}/cloudigrade:{{ new_image_tag.stdout }}
+    shell: podman push quay.io/{{ quay_user }}/cloudigrade:{{ new_image_tag.stdout }}
     args:
       chdir: "{{ cloudigrade_deployment_repo }}"
     when: cloudigrade_deployment_host == 'local'
 
   - name: create / push postigrade
-    shell: docker push quay.io/{{ quay_user }}/postigrade:{{ new_image_tag.stdout }}
+    shell: podman push quay.io/{{ quay_user }}/postigrade:{{ new_image_tag.stdout }}
     args:
       chdir: "{{ postigrade_deployment_repo }}"
     when: postigrade_deployment_host == 'local'


### PR DESCRIPTION
Switching from docker desktop to podman should be as simple as
```
brew install podman
podman machine init
podman machine start
alias docker=podman
```

Since docker machine remains free, I did not update any of our pipelines, as that won’t be a trivial change due to questionable support for podman/buildah across github actions.

Buildah is supported as its own action, but its too orthogonal (now I’m using that word) to how we currently do image builds. With upcoming deploy changes, that may be the time to change our current docker checks to a simpler buildah bud to verify the validity of our Containerfiles.