### PR TITLE
Switch to using sources-monitor-go

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1023,7 +1023,7 @@ objects:
     dependencies:
     - postigrade
     - sources-api
-    - sources-monitor
+    - sources-monitor-go
     - sources-superkey-worker
     kafkaTopics:
     - topicName: platform.sources.event-stream

--- a/deployment/playbooks/roles/clowder/tasks/clowder.yml
+++ b/deployment/playbooks/roles/clowder/tasks/clowder.yml
@@ -93,7 +93,7 @@
   - name: destroy / delete apps in {{ namespace }}
     shell: |
       for app in rbac \
-                 sources-api sources-monitor sources-superkey-worker \
+                 sources-api sources-monitor-go sources-superkey-worker \
                  postigrade cloudigrade
       do
         oc delete app ${app} -n {{ namespace }}


### PR DESCRIPTION
sources-monitor appears to have become sources-monitor-go, this updates our clowdapp and playbook to reference that accordingly.