### PR TITLE
more gracefully delete/disable CloudAccounts if expected related data is missing

### DIFF
--- a/cloudigrade/api/models.py
+++ b/cloudigrade/api/models.py
@@ -193,7 +193,16 @@ class CloudAccount(ExportModelOperationsMixin("CloudAccount"), BaseGenericModel)
             self.save()
         if power_off_instances:
             self._power_off_instances(power_off_time=get_now())
-        self.content_object.disable()
+        if self.content_object:
+            self.content_object.disable()
+        else:
+            logger.error(
+                _(
+                    "content_object is missing and cannot completely disable "
+                    "%(cloud_account)s"
+                ),
+                {"cloud_account": self},
+            )
         if notify_sources:
             from api.tasks.sources import notify_application_availability_task
 


### PR DESCRIPTION
This should address an issue @paraggit experienced in our stage environment, though it is unclear what were the exact circumstances that led to the CloudAccount he was deleting to be put into a broken state.

See also: https://ansible.slack.com/archives/C01PNNPTJR3/p1631609913014300