### PR TITLE
pause cloudtrail events

### DIFF
--- a/cloudigrade/api/clouds/aws/cloudtrail.py
+++ b/cloudigrade/api/clouds/aws/cloudtrail.py
@@ -273,6 +273,20 @@ def _is_relevant_event(occurred_at, aws_account_id, event_type):
             },
         )
         return False
+    if cloud_account.platform_application_is_paused:
+        logger.info(
+            _(
+                "Skipping CloudTrail record %(event_type)s event extraction for AWS "
+                "account ID %(aws_account_id)s because CloudAccount "
+                "%(cloud_account_id)s is paused."
+            ),
+            {
+                "event_type": event_type,
+                "aws_account_id": aws_account_id,
+                "cloud_account_id": cloud_account.id,
+            },
+        )
+        return False
     if cloud_account.enabled_at and cloud_account.enabled_at > parse(occurred_at):
         logger.info(
             _(

--- a/cloudigrade/api/tests/clouds/aws/tasks/cloudtrail/test_analyze_log.py
+++ b/cloudigrade/api/tests/clouds/aws/tasks/cloudtrail/test_analyze_log.py
@@ -857,6 +857,49 @@ class AnalyzeLogTest(TestCase):
         images = list(AwsMachineImage.objects.all())
         self.assertEqual(len(images), 0)
 
+    @patch("api.clouds.aws.tasks.cloudtrail.start_image_inspection")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.get_session")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.delete_messages_from_queue")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.get_object_content_from_s3")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.yield_messages_from_queue")
+    def test_analyze_log_when_account_is_paused(
+        self, mock_receive, mock_s3, mock_del, mock_session, mock_inspection
+    ):
+        """
+        Test appropriate handling when the account ID in the log is paused.
+
+        This can happen if we receive a cloudtrail message after the related
+        CloudAccount has been paused via sources-api interaction.
+
+        The expected result is similar to test_analyze_log_when_account_is_disabled.
+        """
+        self.account.platform_application_is_paused = True
+        self.account.save()
+
+        sqs_message = helper.generate_mock_cloudtrail_sqs_message()
+        ec2_instance_id = util_helper.generate_dummy_instance_id()
+        trail_record = helper.generate_cloudtrail_instances_record(
+            aws_account_id=self.aws_account_id,
+            instance_ids=[ec2_instance_id],
+        )
+        s3_content = {"Records": [trail_record]}
+        mock_receive.return_value = [sqs_message]
+        mock_s3.return_value = json.dumps(s3_content)
+
+        successes, failures = tasks.analyze_log()
+
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(failures), 0)
+        mock_inspection.assert_not_called()
+        mock_del.assert_called()
+
+        instances = list(AwsInstance.objects.all())
+        self.assertEqual(len(instances), 0)
+        events = list(AwsInstanceEvent.objects.all())
+        self.assertEqual(len(events), 0)
+        images = list(AwsMachineImage.objects.all())
+        self.assertEqual(len(images), 0)
+
     @patch("api.clouds.aws.tasks.cloudtrail.aws.delete_messages_from_queue")
     @patch("api.clouds.aws.tasks.cloudtrail.aws.get_object_content_from_s3")
     @patch("api.clouds.aws.tasks.cloudtrail.aws.yield_messages_from_queue")


### PR DESCRIPTION
These changes should improve processing of AWS CloudTrail event data when the related CloudAccount's source is paused.

I've added checks to two places. The `_is_relevant_event` _should_ catch nearly all cases when processing starts, but I put another check deeper in `_process_cloudtrail_message` to be extra sure in case we somehow received and processed a "pause" after the current CloudTrail processing started.