### PR TITLE
Bumping up the CELERY_WORKER_LIMITS_CONTAINER_MEM_LIMIT

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1343,7 +1343,7 @@ parameters:
 - name: CELERY_WORKER_LIMITS_CONTAINER_MEM_LIMIT
   displayName: Cloudigrade Celery Worker Container Memory Limit
   required: true
-  value: 512Mi
+  value: 896Mi
 - name: CELERY_WORKER_LIMITS_CONTAINER_MEM_REQUEST
   displayName: Cloudigrade Celery Worker Container Memory Request
   required: true


### PR DESCRIPTION
- Bumping up the CELERY_WORKER_LIMITS_CONTAINER_MEM_LIMIT by 384Mi to cover the memory spikes of 316Mi seen
with the Azure CLI SDK. So going from 512Mi to 896Mi.