### PR TITLE
remove old cloud_account_name variable from log message 

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -947,7 +947,6 @@ def create_aws_cloud_account(
             "Creating an AwsCloudAccount. "
             "user=%(user)s, "
             "customer_role_arn=%(customer_role_arn)s, "
-            "cloud_account_name=%(cloud_account_name)s, "
             "platform_authentication_id=%(platform_authentication_id)s, "
             "platform_application_id=%(platform_application_id)s, "
             "platform_source_id=%(platform_source_id)s"


### PR DESCRIPTION
(followup to 035c0e1)

found in https://sentry.io/organizations/cloudigrade/issues/2700128771/?project=1270362