### PR TITLE
Added check in the concurrency api so that if the start_date

### DIFF
--- a/cloudigrade/api/views.py
+++ b/cloudigrade/api/views.py
@@ -104,6 +104,10 @@ class DailyConcurrentUsageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin
         """Return the latest allowed start_date."""
         return get_today() - timedelta(days=1)
 
+    def early_start_date_error(self):
+        """Return the error message for specifying an early start_date."""
+        return _("start_date must be same as or after the user creation date.")
+
     def late_start_date_error(self):
         """Return the error message for specifying a late start_date."""
         return _("start_date cannot be today or in the future.")
@@ -145,6 +149,8 @@ class DailyConcurrentUsageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin
             # we do not return anything
             if start_date > self.latest_start_date():
                 errors["start_date"] = [self.late_start_date_error()]
+            if start_date < user.date_joined.date():
+                errors["start_date"] = [self.early_start_date_error()]
         except ValueError:
             errors["start_date"] = [self.invalid_start_date_error()]
 

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -2151,7 +2151,7 @@ Response:
 
     HTTP/1.1 400 Bad Request
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 74
+    Content-Length: 151
     Content-Type: application/json
     Referrer-Policy: same-origin
     X-CLOUDIGRADE-REQUEST-ID: c2d87254-dc29-4c26-9ea7-75f75f8161e6
@@ -2161,6 +2161,9 @@ Response:
     {
         "end_date": [
             "end_date must be same as or after the user creation date."
+        ],
+        "start_date": [
+            "start_date must be same as or after the user creation date."
         ]
     }
 


### PR DESCRIPTION
Added check in the concurrency api so that if the start_date specified specified is before the date the user joined, we
return a 400 and associated error message:
  - "start_date must be same as or after the user creation date."

https://github.com/cloudigrade/cloudigrade/issues/910
