### PR TITLE
Fix the openapi json schema generation for foreign key properties

### DIFF
--- a/cloudigrade/api/serializers.py
+++ b/cloudigrade/api/serializers.py
@@ -66,6 +66,9 @@ class CloudAccountSerializer(ModelSerializer):
         required=False,
     )
 
+    # Foreign key non-string properties
+    user_id = IntegerField(read_only=True)
+
     class Meta:
         model = CloudAccount
         fields = (
@@ -276,6 +279,10 @@ class InstanceSerializer(ModelSerializer):
         required=False,
     )
     instance_id = IntegerField(source="id", read_only=True)
+
+    # Foreign key non-string properties
+    cloud_account_id = IntegerField(read_only=True)
+    machine_image_id = IntegerField(read_only=True)
 
     class Meta:
         model = Instance

--- a/openapi-internal.json
+++ b/openapi-internal.json
@@ -6382,7 +6382,7 @@
             "readOnly": true
           },
           "user_id": {
-            "type": "string",
+            "type": "integer",
             "readOnly": true
           },
           "content_object": {

--- a/openapi.json
+++ b/openapi.json
@@ -843,7 +843,7 @@
             "readOnly": true
           },
           "user_id": {
-            "type": "string",
+            "type": "integer",
             "readOnly": true
           },
           "content_object": {
@@ -896,7 +896,7 @@
         "type": "object",
         "properties": {
           "cloud_account_id": {
-            "type": "string",
+            "type": "integer",
             "readOnly": true
           },
           "created_at": {
@@ -909,7 +909,7 @@
             "readOnly": true
           },
           "machine_image_id": {
-            "type": "string",
+            "type": "integer",
             "readOnly": true
           },
           "updated_at": {


### PR DESCRIPTION
Updated the serializers of the api views to explicitely declare what non-string ForeignKey fields are defined. This allows
the SchemaGenerator to correctly define the openapi json schema for those properties. i.e. account.user_id is now defined as integer instead of string.

https://github.com/cloudigrade/cloudigrade/issues/1021
