### PR TITLE
Downgraded the MachineImage.DoesNotExist error saving an instance

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -342,8 +342,7 @@ def save_instance(account, instance_data, region):
             logger.info(
                 _(
                     "Existing AwsMachineImage %(awsmachineimage_id)s "
-                    "(ec2_ami_id=%(ec2_ami_id)s) found has no "
-                    "MachineImage. This should not happen!"
+                    "(ec2_ami_id=%(ec2_ami_id)s) found has no MachineImage."
                 ),
                 {
                     "awsmachineimage_id": awsmachineimage.id,

--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -339,7 +339,7 @@ def save_instance(account, instance_data, region):
             # We are not sure how this could happen. Whenever we save a new
             # AwsMachineImage, we *should* always follow up with creating
             # its paired MachineImage. Investigate if you see this error!
-            logger.error(
+            logger.info(
                 _(
                     "Existing AwsMachineImage %(awsmachineimage_id)s "
                     "(ec2_ami_id=%(ec2_ami_id)s) found has no "

--- a/cloudigrade/api/tests/clouds/aws/util/test_save_instance.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_save_instance.py
@@ -79,7 +79,7 @@ class SaveInstanceTest(TestCase):
 
         logged_condition = (
             "Existing AwsMachineImage {aws_ami_id} (ec2_ami_id={ec2_ami_id})"
-            " found has no MachineImage. This should not happen!"
+            " found has no MachineImage."
         ).format(aws_ami_id=aws_machine_image.id, ec2_ami_id=ami_id)
         self.assertIn(logged_condition, " ".join(logging_watcher.output))
         self.assertEqual(instance.machine_image.content_object.ec2_ami_id, ami_id)

--- a/cloudigrade/api/tests/clouds/aws/util/test_save_instance.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_save_instance.py
@@ -73,9 +73,15 @@ class SaveInstanceTest(TestCase):
         with self.assertRaises(MachineImage.DoesNotExist):
             aws_machine_image.machine_image.get()
 
-        awsinstance = util.save_instance(account, instances_data[region][0], region)
+        with self.assertLogs("api.clouds.aws.util", level="INFO") as logging_watcher:
+            awsinstance = util.save_instance(account, instances_data[region][0], region)
         instance = awsinstance.instance.get()
 
+        logged_condition = (
+            "Existing AwsMachineImage {aws_ami_id} (ec2_ami_id={ec2_ami_id})"
+            " found has no MachineImage. This should not happen!"
+        ).format(aws_ami_id=aws_machine_image.id, ec2_ami_id=ami_id)
+        self.assertIn(logged_condition, " ".join(logging_watcher.output))
         self.assertEqual(instance.machine_image.content_object.ec2_ami_id, ami_id)
         self.assertEqual(instance.machine_image.status, MachineImage.UNAVAILABLE)
 


### PR DESCRIPTION
- Downgraded the MachineImage.DoesNotExist error while trying to save an instance to just a logger info.
- Updated the test to check the condition was logged.

https://github.com/cloudigrade/cloudigrade/issues/1055