### PR TITLE
add `delete_orphaned_cloud_accounts` queue to celery worker command

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -828,7 +828,7 @@ objects:
             --loglevel info
             --concurrency 1
             --task-events
-            --queues celery,initial_aws_describe_instances,copy_ami_snapshot,copy_ami_to_customer_account,remove_snapshot_ownership,create_volume,enqueue_ready_volumes,delete_snapshot,inspect_pending_images,scale_up_inspection_cluster,attach_volumes_to_cluster,run_inspection_cluster,persist_inspection_cluster_results_task,scale_down_cluster,analyze_log,repopulate_ec2_instance_mapping,create_from_sources_kafka_message,configure_customer_aws_and_create_cloud_account,delete_from_sources_kafka_message,delete_inactive_users,delete_cloud_account,calculate_max_concurrent_usage,notify_application_availability_task,enable_account,repopulate_azure_instance_mapping,launch_inspection_instance,pause_from_sources_kafka_message,unpause_from_sources_kafka_message
+            --queues celery,initial_aws_describe_instances,copy_ami_snapshot,copy_ami_to_customer_account,remove_snapshot_ownership,create_volume,enqueue_ready_volumes,delete_snapshot,inspect_pending_images,scale_up_inspection_cluster,attach_volumes_to_cluster,run_inspection_cluster,persist_inspection_cluster_results_task,scale_down_cluster,analyze_log,repopulate_ec2_instance_mapping,create_from_sources_kafka_message,configure_customer_aws_and_create_cloud_account,delete_from_sources_kafka_message,delete_inactive_users,delete_cloud_account,calculate_max_concurrent_usage,notify_application_availability_task,enable_account,repopulate_azure_instance_mapping,launch_inspection_instance,pause_from_sources_kafka_message,unpause_from_sources_kafka_message,delete_orphaned_cloud_accounts
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
missed this when adding the new queue in https://github.com/cloudigrade/cloudigrade/pull/1079 for https://github.com/cloudigrade/cloudigrade/issues/1070