### PR TITLE
Add image tag to slack payload

### DIFF
--- a/deployment/scripts/cloudigrade_init.sh
+++ b/deployment/scripts/cloudigrade_init.sh
@@ -54,7 +54,7 @@ if [[ -z "${SLACK_TOKEN}" ]]; then
   echo "Cloudigrade Init: SLACK_TOKEN is not defined, not uploading the slack payload"
 else
   slack_payload=`cat /tmp/slack-payload | tail -n 3`
-  slack_payload="${CLOUDIGRADE_ENVIRONMENT} -- $slack_payload"
+  slack_payload="${CLOUDIGRADE_ENVIRONMENT}-${IMAGE_TAG} -- $slack_payload"
   curl -X POST --data-urlencode "payload={\"channel\": \"#cloudmeter-deployments\", \"text\": \"$slack_payload\"}" ${SLACK_TOKEN}
 fi
 


### PR DESCRIPTION
Add IMAGE_TAG to slack payload, so we can quickly see if we're having new or old rollouts in stage/prod.