### PR TITLE
implement prometheus again

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -82,6 +82,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "django_filters",
+    "django_prometheus",
     "generic_relations",
     "health_check",
     "health_check.db",
@@ -97,6 +98,7 @@ LOCAL_APPS = [
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",  # should always be first
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -105,6 +107,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "util.middleware.RequestIDLoggingMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",  # should always be last
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -133,7 +136,7 @@ DATABASES = {
     "default": {
         "ATOMIC_REQUESTS": env("DJANGO_ATOMIC_REQUESTS", default=True),
         "ENGINE": env(
-            "DJANGO_DATABASE_ENGINE", default="django.db.backends.postgresql"
+            "DJANGO_DATABASE_ENGINE", default="django_prometheus.db.backends.postgresql"
         ),
         "CONN_MAX_AGE": env.int("DJANGO_DATABASE_CONN_MAX_AGE", default=0),
     }

--- a/cloudigrade/internal/urls.py
+++ b/cloudigrade/internal/urls.py
@@ -81,6 +81,7 @@ for (prefix, viewset, basename) in routes:
 urlpatterns = [
     path("api-auth/", include("rest_framework.urls")),
     path("healthz/", include("health_check.urls")),
+    path("", include("django_prometheus.urls")),  # serves "/metrics"
     path("admin/", admin.site.urls),
     path("error/", views.fake_error, name="internal-fake-error"),
     path(

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -84,7 +84,7 @@ Response:
     Content-Length: 1189
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 87800892-17ad-4bce-84c2-99fd13bf6de7
+    X-CLOUDIGRADE-REQUEST-ID: fd13bf6d-e7c1-444a-89e6-996ad3f87bd8
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -159,7 +159,7 @@ Response:
     Content-Length: 496
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: c1344a89-e699-4ad3-b87b-d8caf8639b96
+    X-CLOUDIGRADE-REQUEST-ID: caf8639b-963b-49dd-8c05-a8e200bd2e4d
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -205,7 +205,7 @@ Response:
     Content-Length: 2611
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 3bd9ddcc-05a8-4200-bd2e-4d8191415510
+    X-CLOUDIGRADE-REQUEST-ID: 81914155-107e-4c43-b1d3-4dc56862cf62
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -332,7 +332,7 @@ Response:
     Content-Length: 350
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 7edc43f1-d34d-4568-a2cf-620f29a4ef20
+    X-CLOUDIGRADE-REQUEST-ID: 0f29a4ef-203d-49ba-9455-0ef1097b6a24
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -375,7 +375,7 @@ Response:
     Content-Length: 2365
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 3d49bad4-550e-4109-bb6a-247de3dd9ab7
+    X-CLOUDIGRADE-REQUEST-ID: 7de3dd9a-b714-4cb2-a6cf-fc5a69099c77
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -492,7 +492,7 @@ Response:
     Content-Length: 6922
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 14acb226-cffc-4a69-899c-7762750c1978
+    X-CLOUDIGRADE-REQUEST-ID: 62750c19-78c7-4605-8899-9e21a1521ab3
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -757,7 +757,7 @@ Response:
     Content-Length: 1143
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: c7260508-999e-41a1-921a-b38ca6583162
+    X-CLOUDIGRADE-REQUEST-ID: 8ca65831-62c8-46c7-bd1c-e10f9cb3779d
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2061,7 +2061,7 @@ Response:
     Content-Length: 64
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 51d15209-8625-4f41-9ac8-27d761954bb7
+    X-CLOUDIGRADE-REQUEST-ID: d761954b-b7b4-4e78-90cc-1584deea0a10
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2090,7 +2090,7 @@ Response:
     Content-Length: 50
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: ff7fa2ab-df33-4a9c-ae38-0257b4f6bfe6
+    X-CLOUDIGRADE-REQUEST-ID: 57b4f6bf-e651-4152-8986-25df419ac827
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2121,7 +2121,7 @@ Response:
     Content-Length: 112
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: b4ce7810-cc15-44de-aa0a-1039210a4c03
+    X-CLOUDIGRADE-REQUEST-ID: 39210a4c-03c2-4872-94dc-29cc26dea775
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2154,7 +2154,7 @@ Response:
     Content-Length: 151
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: c2d87254-dc29-4c26-9ea7-75f75f8161e6
+    X-CLOUDIGRADE-REQUEST-ID: f75f8161-e687-4008-9217-adcbce84c299
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2190,7 +2190,7 @@ Response:
     Content-Length: 680
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: c8c6c77d-1ce1-4f9c-b377-9da1ef56a61f
+    X-CLOUDIGRADE-REQUEST-ID: a1ef56a6-1ff8-4eb6-9f4b-c9d920f5e963
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2249,7 +2249,7 @@ Response:
     Content-Length: 2017
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 5a121f5b-b107-4859-ad02-d4f93bd15d12
+    X-CLOUDIGRADE-REQUEST-ID: f93bd15d-1298-4424-b500-34a8acbbf0e6
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2361,7 +2361,7 @@ Request:
 
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
-        account_arn="arn:aws:iam::761488217673:role/role-for-cloudigrade" \
+        account_arn="arn:aws:iam::335555691572:role/role-for-cloudigrade" \
         platform_authentication_id="2281" \
         platform_application_id="4617" \
         platform_source_id="2289"
@@ -2375,7 +2375,7 @@ Response:
     Content-Length: 511
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 4bc9d920-f5e9-43cc-8bea-bedff5aefbcf
+    X-CLOUDIGRADE-REQUEST-ID: dff5aefb-cf1f-44dc-89fe-3009c864715f
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2383,8 +2383,8 @@ Response:
         "account_id": 3,
         "cloud_type": "aws",
         "content_object": {
-            "account_arn": "arn:aws:iam::761488217673:role/role-for-cloudigrade",
-            "aws_account_id": "761488217673",
+            "account_arn": "arn:aws:iam::335555691572:role/role-for-cloudigrade",
+            "aws_account_id": "335555691572",
             "aws_cloud_account_id": 2,
             "created_at": "2020-05-18T13:51:59.722367Z",
             "updated_at": "2020-05-18T13:51:59.722367Z"
@@ -2408,7 +2408,7 @@ Request:
 
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
-        account_arn="arn:aws:iam::761488217673:role/role-for-cloudigrade" \
+        account_arn="arn:aws:iam::335555691572:role/role-for-cloudigrade" \
         platform_authentication_id="1553" \
         platform_application_id="4104" \
         platform_source_id="8725"
@@ -2422,7 +2422,7 @@ Response:
     Content-Length: 157
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: dcc9fe30-09c8-4471-9fc1-30745bcaa113
+    X-CLOUDIGRADE-REQUEST-ID: 745bcaa1-13f4-4be6-af0a-7c41e606f185
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2443,8 +2443,8 @@ Request:
 
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="azure" \
-        subscription_id="3a17c6d1-e2e3-40c7-80b2-866b814ef21d" \
-        tenant_id="f40be6ef-0a7c-41e6-86f1-85aa9192e037" \
+        subscription_id="6b814ef2-1d25-4de4-906c-ec15ef1a6a10" \
+        tenant_id="aa9192e0-373a-47c6-91e2-e3a0c780b286" \
         platform_authentication_id="9861" \
         platform_application_id="2407" \
         platform_source_id="5081"
@@ -2458,7 +2458,7 @@ Response:
     Content-Length: 523
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: f407ca72-6eaf-4a07-bfeb-ddf653b84014
+    X-CLOUDIGRADE-REQUEST-ID: f653b840-145a-421f-9bb1-0758592d02d4
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2468,8 +2468,8 @@ Response:
         "content_object": {
             "azure_cloud_account_id": 2,
             "created_at": "2020-05-18T13:51:59.722367Z",
-            "subscription_id": "3a17c6d1-e2e3-40c7-80b2-866b814ef21d",
-            "tenant_id": "f40be6ef-0a7c-41e6-86f1-85aa9192e037",
+            "subscription_id": "6b814ef2-1d25-4de4-906c-ec15ef1a6a10",
+            "tenant_id": "aa9192e0-373a-47c6-91e2-e3a0c780b286",
             "updated_at": "2020-05-18T13:51:59.722367Z"
         },
         "created_at": "2020-05-18T13:51:59.722367Z",

--- a/poetry.lock
+++ b/poetry.lock
@@ -556,7 +556,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "crc-bonfire"
-version = "2.18.5"
+version = "2.19.1"
 description = "A CLI tool used to deploy ephemeral environments for testing cloud.redhat.com applications"
 category = "dev"
 optional = false
@@ -582,7 +582,7 @@ test = ["flake8"]
 
 [[package]]
 name = "cryptography"
-version = "36.0.0"
+version = "36.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -716,6 +716,17 @@ python-versions = "*"
 
 [package.dependencies]
 Django = ">=2.0.1"
+
+[[package]]
+name = "django-prometheus"
+version = "2.1.0"
+description = "Django middlewares to monitor your application with Prometheus.io."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+prometheus-client = ">=0.7"
 
 [[package]]
 name = "django-timezone-field"
@@ -986,7 +997,7 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 
 [[package]]
 name = "isodate"
-version = "0.6.0"
+version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
 category = "main"
 optional = false
@@ -1061,7 +1072,7 @@ testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3
 
 [[package]]
 name = "jsonschema"
-version = "4.2.1"
+version = "4.3.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -1621,7 +1632,7 @@ tests = ["pytest (>=4.6.9)", "pytest-cov (>=2.8.1)", "sphinx (>=1.8.5)", "pytest
 name = "prometheus-client"
 version = "0.12.0"
 description = "Python client for the Prometheus monitoring system."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1914,7 +1925,7 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qtconsole"
-version = "5.2.1"
+version = "5.2.2"
 description = "Jupyter Qt console"
 category = "dev"
 optional = false
@@ -2156,7 +2167,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.2"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
@@ -2308,7 +2319,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f74176061200157a98e43eae8592b8f6008463681e742a24ad001da9e68d5da2"
+content-hash = "4ea49ce01ccea1edc91b158b634c1516bf3c063c90ef4e5c10f32337026506cd"
 
 [metadata.files]
 amqp = [
@@ -2615,31 +2626,30 @@ coverage = [
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 crc-bonfire = [
-    {file = "crc-bonfire-2.18.5.tar.gz", hash = "sha256:1c43a424782f369e5804f8614698e95415339ddef4df591470f5b00cc07d6afd"},
-    {file = "crc_bonfire-2.18.5-py3-none-any.whl", hash = "sha256:0b288164e3dcc429e2388b97661985bb33df13f22aff17f8c05e0e3f2825d4a7"},
+    {file = "crc-bonfire-2.19.1.tar.gz", hash = "sha256:f218b7287076935f362dfc09a686bc3c807e69ff870ac9770617b96a2091ac85"},
+    {file = "crc_bonfire-2.19.1-py3-none-any.whl", hash = "sha256:5ccbd5a7afa5db62611fb0594f400aaf10a124f8a5eda5fc990798cf6f459cd0"},
 ]
 cryptography = [
-    {file = "cryptography-36.0.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:9511416e85e449fe1de73f7f99b21b3aa04fba4c4d335d30c486ba3756e3a2a6"},
-    {file = "cryptography-36.0.0-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:97199a13b772e74cdcdb03760c32109c808aff7cd49c29e9cf4b7754bb725d1d"},
-    {file = "cryptography-36.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:494106e9cd945c2cadfce5374fa44c94cfadf01d4566a3b13bb487d2e6c7959e"},
-    {file = "cryptography-36.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6fbbbb8aab4053fa018984bb0e95a16faeb051dd8cca15add2a27e267ba02b58"},
-    {file = "cryptography-36.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:684993ff6f67000a56454b41bdc7e015429732d65a52d06385b6e9de6181c71e"},
-    {file = "cryptography-36.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c702855cd3174666ef0d2d13dcc879090aa9c6c38f5578896407a7028f75b9f"},
-    {file = "cryptography-36.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d91bc9f535599bed58f6d2e21a2724cb0c3895bf41c6403fe881391d29096f1d"},
-    {file = "cryptography-36.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b17d83b3d1610e571fedac21b2eb36b816654d6f7496004d6a0d32f99d1d8120"},
-    {file = "cryptography-36.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:8982c19bb90a4fa2aad3d635c6d71814e38b643649b4000a8419f8691f20ac44"},
-    {file = "cryptography-36.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:24469d9d33217ffd0ce4582dfcf2a76671af115663a95328f63c99ec7ece61a4"},
-    {file = "cryptography-36.0.0-cp36-abi3-win32.whl", hash = "sha256:f6a5a85beb33e57998dc605b9dbe7deaa806385fdf5c4810fb849fcd04640c81"},
-    {file = "cryptography-36.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:2deab5ec05d83ddcf9b0916319674d3dae88b0e7ee18f8962642d3cde0496568"},
-    {file = "cryptography-36.0.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2049f8b87f449fc6190350de443ee0c1dd631f2ce4fa99efad2984de81031681"},
-    {file = "cryptography-36.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a776bae1629c8d7198396fd93ec0265f8dd2341c553dc32b976168aaf0e6a636"},
-    {file = "cryptography-36.0.0-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:aa94d617a4cd4cdf4af9b5af65100c036bce22280ebb15d8b5262e8273ebc6ba"},
-    {file = "cryptography-36.0.0-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:5c49c9e8fb26a567a2b3fa0343c89f5d325447956cc2fc7231c943b29a973712"},
-    {file = "cryptography-36.0.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ef216d13ac8d24d9cd851776662f75f8d29c9f2d05cdcc2d34a18d32463a9b0b"},
-    {file = "cryptography-36.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231c4a69b11f6af79c1495a0e5a85909686ea8db946935224b7825cfb53827ed"},
-    {file = "cryptography-36.0.0-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:f92556f94e476c1b616e6daec5f7ddded2c082efa7cee7f31c7aeda615906ed8"},
-    {file = "cryptography-36.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d73e3a96c38173e0aa5646c31bf8473bc3564837977dd480f5cbeacf1d7ef3a3"},
-    {file = "cryptography-36.0.0.tar.gz", hash = "sha256:52f769ecb4ef39865719aedc67b4b7eae167bafa48dbc2a26dd36fa56460507f"},
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b"},
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3"},
+    {file = "cryptography-36.0.1-cp36-abi3-win32.whl", hash = "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca"},
+    {file = "cryptography-36.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
+    {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
 debugpy = [
     {file = "debugpy-1.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:70b422c63a833630c33e3f9cdbd9b6971f8c5afd452697e464339a21bbe862ba"},
@@ -2703,6 +2713,10 @@ django-health-check = [
 django-model-utils = [
     {file = "django-model-utils-4.1.1.tar.gz", hash = "sha256:eb5dd05ef7d7ce6bc79cae54ea7c4a221f6f81e2aad7722933aee66489e7264b"},
     {file = "django_model_utils-4.1.1-py3-none-any.whl", hash = "sha256:ef7c440024e797796a3811432abdd2be8b5225ae64ef346f8bfc6de7d8e5d73c"},
+]
+django-prometheus = [
+    {file = "django-prometheus-2.1.0.tar.gz", hash = "sha256:dd3f8da1399140fbef5c00d1526a23d1ade286b144281c325f8e409a781643f2"},
+    {file = "django_prometheus-2.1.0-py2.py3-none-any.whl", hash = "sha256:c338d6efde1ca336e90c540b5e87afe9287d7bcc82d651a778f302b0be17a933"},
 ]
 django-timezone-field = [
     {file = "django-timezone-field-4.2.1.tar.gz", hash = "sha256:97780cde658daa5094ae515bb55ca97c1352928ab554041207ad515dee3fe971"},
@@ -2780,8 +2794,8 @@ ipywidgets = [
     {file = "ipywidgets-7.6.5.tar.gz", hash = "sha256:00974f7cb4d5f8d494c19810fedb9fa9b64bffd3cda7c2be23c133a1ad3c99c5"},
 ]
 isodate = [
-    {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
-    {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
+    {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
+    {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -2804,8 +2818,8 @@ jsonpickle = [
     {file = "jsonpickle-2.0.0.tar.gz", hash = "sha256:0be49cba80ea6f87a168aa8168d717d00c6ca07ba83df3cec32d3b30bfe6fb9a"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.2.1-py3-none-any.whl", hash = "sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c"},
-    {file = "jsonschema-4.2.1.tar.gz", hash = "sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8"},
+    {file = "jsonschema-4.3.0-py3-none-any.whl", hash = "sha256:ab7069946a3ad2037e79a5cdc8d0e9a74cd00721d426d75c5d69a6707c778218"},
+    {file = "jsonschema-4.3.0.tar.gz", hash = "sha256:cb7f57b40f870409d7571844d0623f66d8078c90a9c255d9a4d4314b5ec3fc7c"},
 ]
 jupyter = [
     {file = "jupyter-1.0.0-py2.py3-none-any.whl", hash = "sha256:5b290f93b98ffbc21c0c7e749f054b3267782166d72fa5e3ed1ed4eaf34a2b78"},
@@ -3350,8 +3364,8 @@ pyzmq = [
     {file = "pyzmq-22.3.0.tar.gz", hash = "sha256:8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c"},
 ]
 qtconsole = [
-    {file = "qtconsole-5.2.1-py3-none-any.whl", hash = "sha256:37317e9ee7faa2faaa927b09a6ec24a45cd7b19c9975d97ab6fd8985354839f1"},
-    {file = "qtconsole-5.2.1.tar.gz", hash = "sha256:bb3b9f0d674055e627c1097779c0d5e028176706d3b6be39cf52235f6ddcc88e"},
+    {file = "qtconsole-5.2.2-py3-none-any.whl", hash = "sha256:4aa6a3e600e0c8cf16853f2378311bc2371f57cb0f22ecfc28994f4cf409ee2e"},
+    {file = "qtconsole-5.2.2.tar.gz", hash = "sha256:8f9db97b27782184efd0a0f2d57ea3bd852d053747a2e442a9011329c082976d"},
 ]
 qtpy = [
     {file = "QtPy-1.11.3-py2.py3-none-any.whl", hash = "sha256:e121fbee8e95645af29c5a4aceba8d657991551fc1aa3b6b6012faf4725a1d20"},
@@ -3427,8 +3441,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
-    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tornado = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ app-common-python = "^0.1.8"
 azure-mgmt-resourcegraph = "^8.0.0"
 azure-mgmt-resource = "^19.0.0"
 azure-cli-core = "^2.27.2"
+django-prometheus = "~=2.1.0"
+
 
 [tool.poetry.dev-dependencies]
 jinja2 = "*"


### PR DESCRIPTION
Since *some* data is required for SRE onboarding, this just serves the standard out-of-the-box metrics from `django-prometheus`. We can add our models and more interesting things later as we see fit.