### PR TITLE
Fix SysConfig OpenApi Schema issues

### DIFF
--- a/cloudigrade/api/schemas.py
+++ b/cloudigrade/api/schemas.py
@@ -74,9 +74,6 @@ class SysconfigSchema(AutoSchema):
                                                                     },
                                                                 },
                                                             },
-                                                            "additionalProperties": {
-                                                                "type": "string"
-                                                            },
                                                         },
                                                     },
                                                     "Version": {"type": "string"},
@@ -88,7 +85,10 @@ class SysconfigSchema(AutoSchema):
                                         "type": "string",
                                         "format": "uri",
                                     },
-                                    "version": {"type": "string"},
+                                    "version": {
+                                        "type": "string",
+                                        "nullable": True,
+                                    },
                                 },
                             }
                         }

--- a/cloudigrade/api/tests/test_schemas.py
+++ b/cloudigrade/api/tests/test_schemas.py
@@ -42,9 +42,6 @@ class SchemaTestCase(TestCase):
                                                                 },
                                                             },
                                                         },
-                                                        "additionalProperties": {
-                                                            "type": "string"
-                                                        },
                                                     },
                                                 },
                                                 "Version": {"type": "string"},
@@ -56,7 +53,7 @@ class SchemaTestCase(TestCase):
                                     "type": "string",
                                     "format": "uri",
                                 },
-                                "version": {"type": "string"},
+                                "version": {"type": "string", "nullable": True},
                             },
                         }
                     }

--- a/openapi.json
+++ b/openapi.json
@@ -462,9 +462,6 @@
                                       "type": "string"
                                     }
                                   }
-                                },
-                                "additionalProperties": {
-                                  "type": "string"
                                 }
                               }
                             },
@@ -480,7 +477,8 @@
                       "format": "uri"
                     },
                     "version": {
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     }
                   }
                 }


### PR DESCRIPTION
- When specifying an additionalProperties object schema and properties with the latest OpenAPI generators (5.x), only one of the two is getting honored. Thus causing the validation failure as the generator thinks it wanted only a string when an array was provided for Action. The fix for this is to use either allOf or simply using the implied boolean default of True for additionalProperties which allows for additional string properties which is what we need.
- Version field provided is null, so we need the nullable option for it.
- Updated the openapi.json
- Updated the schema test

https://github.com/cloudigrade/cloudigrade/issues/1083