### PR TITLE
various minor fixes

### DIFF
--- a/cloudigrade/util/aws/arn.py
+++ b/cloudigrade/util/aws/arn.py
@@ -33,7 +33,7 @@ class AwsArn(object):
     """
 
     arn_regex = re.compile(
-        r"^arn:(?P<partition>\w+):(?P<service>\w+):"
+        r"^arn:(?P<partition>\w+(?:-\w+)*):(?P<service>\w+):"
         r"(?P<region>\w+(?:-\w+)+)?:"
         r"(?P<account_id>\d{1,12})?:"
         r"(?P<resource_type>[^:/]+)"

--- a/cloudigrade/util/aws/sqs.py
+++ b/cloudigrade/util/aws/sqs.py
@@ -141,7 +141,7 @@ def delete_messages_from_queue(queue_url, messages):
     sqs_queue = _get_queue(queue_url)
 
     messages_to_delete = [
-        {"Id": message.message_id, "ReceiptHandle": message._receipt_handle}
+        {"Id": message.message_id, "ReceiptHandle": message.receipt_handle}
         for message in messages
     ]
 

--- a/cloudigrade/util/tests/aws/test_arn.py
+++ b/cloudigrade/util/tests/aws/test_arn.py
@@ -65,6 +65,14 @@ class UtilAwsArnTest(TestCase):
         with self.assertRaises(InvalidArn):
             AwsArn(mock_arn)
 
+    def test_parse_arn_with_various_known_partitions(self):
+        """Assert successful ARN parsing with various known partitions."""
+        partitions = ("aws", "aws-cn", "aws-us-gov")
+        for partition in partitions:
+            mock_arn = helper.generate_dummy_arn(partition=partition)
+            arn_object = AwsArn(mock_arn)
+            self.assertEqual(arn_object.partition, partition)
+
     def test_parse_arn_with_slash_separator(self):
         """Assert successful ARN parsing with a slash separator."""
         mock_arn = helper.generate_dummy_arn(resource_separator="/")

--- a/cloudigrade/util/tests/aws/test_ec2.py
+++ b/cloudigrade/util/tests/aws/test_ec2.py
@@ -529,7 +529,7 @@ class UtilAwsEc2Test(TestCase):
         mock_session = Mock()
         mock_ec2_client = mock_session.client.return_value
         mock_original_image = Mock()
-        mock_copied_image_dict = helper.generate_mock_image_dict()
+        mock_copied_image_dict = {"ImageId": helper.generate_dummy_image_id()}
         mock_ec2_client.copy_image.return_value = mock_copied_image_dict
 
         image_id = mock_original_image.id

--- a/cloudigrade/util/tests/aws/test_sqs.py
+++ b/cloudigrade/util/tests/aws/test_sqs.py
@@ -159,9 +159,17 @@ class UtilAwsSqsTest(TestCase):
     def test_delete_message_from_queue(self):
         """Assert that messages are deleted from SQS queue."""
         mock_queue_url = "https://123.abc"
+        message_data = [
+            [str(uuid.uuid4()), "message 1", str(uuid.uuid4())],
+            [str(uuid.uuid4()), "message 2", str(uuid.uuid4())],
+        ]
         mock_messages_to_delete = [
-            helper.generate_mock_sqs_message(str(uuid.uuid4()), "", str(uuid.uuid4())),
-            helper.generate_mock_sqs_message(str(uuid.uuid4()), "", str(uuid.uuid4())),
+            helper.generate_mock_sqs_message(*message_data[0]),
+            helper.generate_mock_sqs_message(*message_data[1]),
+        ]
+        expected_delete_entries = [
+            {"Id": message_data[0][0], "ReceiptHandle": message_data[0][2]},
+            {"Id": message_data[1][0], "ReceiptHandle": message_data[1][2]},
         ]
         mock_response = {
             "ResponseMetadata": {
@@ -193,6 +201,7 @@ class UtilAwsSqsTest(TestCase):
             )
 
         self.assertEqual(mock_response, actual_response)
+        mock_queue.delete_messages.assert_called_with(Entries=expected_delete_entries)
 
     def test_delete_message_from_queue_with_empty_list(self):
         """Assert an empty list of messages handled by delete."""

--- a/cloudigrade/util/tests/helper.py
+++ b/cloudigrade/util/tests/helper.py
@@ -807,8 +807,8 @@ def generate_mock_sqs_message(message_id, body, receipt_handle):
 
     """
     mock_message = Mock()
-    mock_message.Id = message_id
-    mock_message.ReceiptHandle = receipt_handle
+    mock_message.message_id = message_id
+    mock_message.receipt_handle = receipt_handle
     mock_message.body = body
     return mock_message
 

--- a/cloudigrade/util/tests/helper.py
+++ b/cloudigrade/util/tests/helper.py
@@ -711,27 +711,6 @@ def generate_mock_image(image_id=None, encrypted=False, state=None):
     return mock_image
 
 
-def generate_mock_image_dict(image_id=None):
-    """
-    Generate a mocked EC2 image dict.
-
-    Some of the AWS/boto3 APIs return a dict object like this instead of the
-    EC2 Image object.
-
-    Args:
-        image_id (str): The AMI image id.
-
-    Returns:
-        Mock: A dict with attributes similar to what boto3 produces.
-
-    """
-    if image_id is None:
-        image_id = generate_dummy_image_id()
-
-    mock_image = {"ImageId": image_id}
-    return mock_image
-
-
 def generate_mock_snapshot(
     snapshot_id=None, encrypted=False, state=None, owner_id=None
 ):

--- a/cloudigrade/util/tests/test_helper.py
+++ b/cloudigrade/util/tests/test_helper.py
@@ -223,17 +223,6 @@ class UtilHelperTest(TestCase):
         self.assertTrue(user.is_superuser)
         self.assertEqual(user.date_joined, date_joined)
 
-    def test_generate_mock_image_dict(self):
-        """Assert generation of an image-like dict."""
-        image_dict = helper.generate_mock_image_dict()
-        self.assertIn("ImageId", image_dict)
-
-    def test_generate_mock_image_dict_with_args(self):
-        """Assert generation of an image-like dict with specified arguments."""
-        image_id = helper.generate_dummy_image_id()
-        image_dict = helper.generate_mock_image_dict(image_id)
-        self.assertEqual(image_dict["ImageId"], image_id)
-
     def test_get_test_user_creates(self):
         """Assert get_test_user creates a user when it doesn't yet exist."""
         user = helper.get_test_user()


### PR DESCRIPTION
I found and fixed a few minor problems as I've been digging through and refactoring our test data generators.

- `AwsArn` class previously failed to support `aws-cn` and `aws-us-gov`. Though we don't fully support them yet either, it's best to be prepared for when we will in the future.
- Mocked SQS delete response was very wrong. We were never asserting the related calls/response in the test, or else we would have noticed that it was leveraging Mock's magic property creation. Now we assert the expected values correctly.
- The actual SQS delete response code was needlessly using a protected `_receipt_handle` property; I confirmed manually that the `receipt_handle` is a supported "public" property and updated our call.
- Removed `generate_mock_image_dict` because it's only used once and its output is trivially simple to define. I wonder if we once had much more use of that function which has since been refactored away or if it used to be more complicated. Either way, KISS.