### PR TITLE
1118 add celery internal metrics

### DIFF
--- a/cloudigrade/config/wsgi.py
+++ b/cloudigrade/config/wsgi.py
@@ -3,6 +3,11 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+from internal import metrics
+
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 
 application = get_wsgi_application()
+
+metrics.CeleryMetrics().listener()

--- a/cloudigrade/internal/metrics.py
+++ b/cloudigrade/internal/metrics.py
@@ -1,0 +1,189 @@
+"""Celery Metrics."""
+import logging
+import re
+import threading
+
+from django.utils.translation import gettext as _
+from prometheus_client import Counter, Gauge, Histogram
+
+from config.celery import app as celery_app
+
+
+logger = logging.getLogger(__name__)
+
+
+class CeleryMetrics:
+    """Celery Metrics class for processing and exposing Prometheus metrics."""
+
+    def __init__(self, buckets=None):
+        """Celery Metrics Initializer."""
+        self.listener_started = False
+        self.state_counters = {
+            "task-sent": Counter(
+                "celery_task_sent",
+                "Sent when a task message is published.",
+                [
+                    "name",
+                    "hostname",
+                ],
+            ),
+            "task-received": Counter(
+                "celery_task_received",
+                "Sent when the worker receives a task.",
+                ["name", "hostname"],
+            ),
+            "task-started": Counter(
+                "celery_task_started",
+                "Sent just before the worker executes the task.",
+                [
+                    "name",
+                    "hostname",
+                ],
+            ),
+            "task-succeeded": Counter(
+                "celery_task_succeeded",
+                "Sent if the task executed successfully.",
+                ["name", "hostname"],
+            ),
+            "task-failed": Counter(
+                "celery_task_failed",
+                "Sent if the execution of the task failed.",
+                ["name", "hostname", "exception"],
+            ),
+            "task-rejected": Counter(
+                "celery_task_rejected",
+                # pylint: disable=line-too-long
+                "The task was rejected by the worker, "
+                "possibly to be re-queued or moved to a dead letter queue.",
+                ["name", "hostname"],
+            ),
+            "task-revoked": Counter(
+                "celery_task_revoked",
+                "Sent if the task has been revoked.",
+                ["name", "hostname"],
+            ),
+            "task-retried": Counter(
+                "celery_task_retried",
+                "Sent if the task failed, but will be retried in the future.",
+                ["name", "hostname"],
+            ),
+        }
+        self.celery_worker_up = Gauge(
+            "celery_worker_up",
+            "Indicates if a worker has recently sent a heartbeat.",
+            ["hostname"],
+        )
+        self.worker_tasks_active = Gauge(
+            "celery_worker_tasks_active",
+            "The number of tasks the worker is currently processing",
+            ["hostname"],
+        )
+        self.celery_task_runtime = Histogram(
+            "celery_task_runtime",
+            "Histogram of task runtime measurements.",
+            ["name", "hostname"],
+            buckets=buckets or Histogram.DEFAULT_BUCKETS,
+        )
+
+    def handle_task_event(self, event):
+        """Handle Celery task events."""
+        self.state.event(event)
+        task = self.state.tasks.get(event["uuid"])
+        logger.debug(
+            _("Received celery event='%s' for task='%s'"), event["type"], task.name
+        )
+
+        counter = self.state_counters.get(event["type"])
+        if not counter:
+            logger.warning(_("No celery counter matches task state='%s'"), task.state)
+            return
+
+        labels = {}
+        # pylint: disable=protected-access
+        for labelname in counter._labelnames:
+            value = getattr(task, labelname)
+            if labelname == "exception":
+                logger.debug(value)
+                value = get_exception_class(value)
+            labels[labelname] = value
+
+        counter.labels(**labels).inc()
+        logger.debug(
+            _("Incremented celery metric='%s' labels='%s'"), counter._name, labels
+        )
+
+        if event["type"] == "task-succeeded":
+            self.celery_task_runtime.labels(**labels).observe(task.runtime)
+            logger.debug(
+                _("Observed celery metric='%s' labels='%s': %ss"),
+                self.celery_task_runtime._name,
+                labels,
+                task.runtime,
+            )
+
+    def handle_worker_status(self, event, is_online):
+        """Handle Celery worker status updates."""
+        value = 1 if is_online else 0
+        event_name = "worker-online" if is_online else "worker-offline"
+        hostname = event["hostname"]
+        logger.debug(
+            _("Received celery event='%s' for hostname='%s'"), event_name, hostname
+        )
+        self.celery_worker_up.labels(hostname=hostname).set(value)
+
+    def handle_worker_heartbeat(self, event):
+        """Handle Celery worker heartbeats."""
+        logger.debug(
+            _("Received celery event='%s' for worker='%s'"),
+            event["type"],
+            event["hostname"],
+        )
+
+        worker_state = self.state.event(event)[0][0]
+        active = worker_state.active or 0
+        up = 1 if worker_state.alive else 0
+        self.celery_worker_up.labels(hostname=event["hostname"]).set(up)
+        self.worker_tasks_active.labels(hostname=event["hostname"]).set(active)
+        logger.debug(
+            _("Updated celery gauge='%s' value='%s'"),
+            self.worker_tasks_active._name,
+            active,
+        )
+        logger.debug(
+            _("Updated celery gauge='%s' value='%s'"), self.celery_worker_up._name, up
+        )
+
+    def listener(self):
+        """If not started, start the Celery event handler in a thread."""
+        if self.listener_started:
+            logger.info(_("Celery Metrics Listener already started"))
+            return
+        logger.info(_("Celery Metrics Listener started ..."))
+        self.listener_started = True
+        threading.Thread(target=self.celery_handler).start()
+
+    def celery_handler(self):
+        """Register and trigger Celery handlers on events."""
+        self.app = celery_app
+        self.state = self.app.events.State()
+
+        handlers = {
+            "worker-heartbeat": self.handle_worker_heartbeat,
+            "worker-online": lambda event: self.handle_worker_status(event, True),
+            "worker-offline": lambda event: self.handle_worker_status(event, False),
+        }
+        for key in self.state_counters:
+            handlers[key] = self.handle_task_event
+
+        with self.app.connection() as connection:
+            recv = self.app.events.Receiver(connection, handlers=handlers)
+            recv.capture(limit=None, timeout=None, wakeup=True)
+
+
+exception_pattern = re.compile(r"^(\w+)\(")
+
+
+def get_exception_class(exception_name: str):
+    """Given the exception name, return the exception class."""
+    m = exception_pattern.match(exception_name)
+    return m.group(1)

--- a/cloudigrade/internal/metrics.py
+++ b/cloudigrade/internal/metrics.py
@@ -184,13 +184,13 @@ class CeleryMetrics:
 
         while True:
             try:
-                with self.app.connection() as connection:
-                    recv = self.app.events.Receiver(connection, handlers=handlers)
-                    logger.info(
-                        _("Capturing Celery Events from %s"),
-                        self.app.connection.as_uri(),
-                    )
-                    recv.capture(limit=None, timeout=None, wakeup=True)
+                recv = self.app.events.Receiver(
+                    self.app.connection(), handlers=handlers
+                )
+                logger.info(
+                    _("Capturing Celery Events from %s"), self.app.connection().as_uri()
+                )
+                recv.capture(limit=None, timeout=None, wakeup=True)
 
             except (KeyboardInterrupt, SystemExit):
                 raise

--- a/cloudigrade/internal/tests/test_metrics.py
+++ b/cloudigrade/internal/tests/test_metrics.py
@@ -53,7 +53,7 @@ class InternalMetricsTest(TestCase):
         mock_recv = MagicMock()
         mock_recv().capture = mock_capture
         mock_celery_app.connection = MagicMock()
-        mock_celery_app.connection.as_uri.return_value = self.broker_url
+        mock_celery_app.connection().as_uri.return_value = self.broker_url
         mock_celery_app.events = MagicMock(Receiver=mock_recv)
         with self.assertRaises(SystemExit), self.assertLogs(
             "internal.metrics", level="INFO"
@@ -77,7 +77,7 @@ class InternalMetricsTest(TestCase):
         mock_recv = MagicMock()
         mock_recv().capture = mock_capture
         mock_celery_app.connection = MagicMock()
-        mock_celery_app.connection.as_uri.return_value = self.broker_url
+        mock_celery_app.connection().as_uri.return_value = self.broker_url
         mock_celery_app.events = MagicMock(Receiver=mock_recv)
         with self.assertRaises(SystemExit), self.assertLogs(
             "internal.metrics", level="INFO"

--- a/cloudigrade/internal/tests/test_metrics.py
+++ b/cloudigrade/internal/tests/test_metrics.py
@@ -1,0 +1,208 @@
+"""Collection of tests for Celery Metrics in the internal API."""
+
+import uuid
+from threading import Thread
+from unittest.mock import MagicMock, patch
+
+import faker
+from django.test import TestCase
+
+from internal import metrics
+
+
+_faker = faker.Faker()
+metrics_listener_retry_interval = 1
+celery_metrics = metrics.CeleryMetrics(interval=metrics_listener_retry_interval)
+
+
+class InternalMetricsTest(TestCase):
+    """
+    Internal Celery Metrics test case.
+
+    These tests verify that the Prometheus counters labels are appropriately
+    updated upon receiving Celery task events.
+    """
+
+    def setUp(self):
+        """Set up test data."""
+        self.task_name = "api.analyze_logs"
+        self.broker_url = "redis://" + _faker.hostname() + ":6379"
+        self.event_uuid = str(uuid.uuid4())
+        self.hostname = "celery@" + _faker.hostname()
+        self.task = MagicMock()
+        self.task.name = self.task_name
+        self.task.hostname = self.hostname
+
+    def test_listener(self):
+        """Test the listener gets started."""
+        thread = celery_metrics.listener(daemon=True)
+        self.assertIsNot(thread, None)
+        self.assertIsInstance(thread, Thread)
+        self.assertTrue(celery_metrics.listener_started)
+
+    def test_listener_already_started(self):
+        """Test the listener is already started."""
+        celery_metrics.listener_started = True
+        thread = celery_metrics.listener(daemon=True)
+        self.assertIsNone(thread)
+
+    @patch("internal.metrics.celery_app")
+    def test_celery_handler_system_exit(self, mock_celery_app):
+        """Test the celery_handler with a system exit exception."""
+        mock_capture = MagicMock(side_effect=SystemExit)
+        mock_recv = MagicMock()
+        mock_recv().capture = mock_capture
+        mock_celery_app.connection = MagicMock()
+        mock_celery_app.connection.as_uri.return_value = self.broker_url
+        mock_celery_app.events = MagicMock(Receiver=mock_recv)
+        with self.assertRaises(SystemExit), self.assertLogs(
+            "internal.metrics", level="INFO"
+        ) as logging_watcher:
+            celery_metrics.celery_handler()
+
+        info_messages = {
+            record.message
+            for record in logging_watcher.records
+            if record.levelname == "INFO"
+        }
+
+        expected_info_message = f"Capturing Celery Events from {self.broker_url}"
+        self.assertIn(expected_info_message, info_messages)
+
+    @patch("internal.metrics.celery_app")
+    def test_celery_handler_exception(self, mock_celery_app):
+        """Test exceptions in the celery_handler."""
+        exception_name = "bad_exception"
+        mock_capture = MagicMock(side_effect=[Exception(exception_name), SystemExit])
+        mock_recv = MagicMock()
+        mock_recv().capture = mock_capture
+        mock_celery_app.connection = MagicMock()
+        mock_celery_app.connection.as_uri.return_value = self.broker_url
+        mock_celery_app.events = MagicMock(Receiver=mock_recv)
+        with self.assertRaises(SystemExit), self.assertLogs(
+            "internal.metrics", level="INFO"
+        ) as logging_watcher:
+            celery_metrics.celery_handler()
+
+        info_messages = {
+            record.message
+            for record in logging_watcher.records
+            if record.levelname == "INFO"
+        }
+        expected_info_messages = [
+            f"Capturing Celery Events from {self.broker_url}",
+            f"Celery Metrics Listener Exception {exception_name},"
+            f" retrying in {metrics_listener_retry_interval} seconds.",
+        ]
+
+        for expected_info_message in expected_info_messages:
+            self.assertIn(expected_info_message, info_messages)
+
+    def test_task_started_event(self):
+        """Test the handle_task_event handler for a task-started event."""
+        event = {
+            "type": "task-started",
+            "hostname": self.hostname,
+            "uuid": self.event_uuid,
+        }
+        task_started_counter = MagicMock(labels=MagicMock())
+        celery_metrics.state_counters = {"task-started": task_started_counter}
+        tasks = {self.event_uuid: self.task}
+        celery_metrics.state = MagicMock(tasks=tasks)
+        celery_metrics.handle_task_event(event)
+        task_started_counter.labels.assert_called_with(
+            name=self.task_name, hostname=self.hostname
+        )
+        task_started_counter.labels.return_value.inc.assert_called_with()
+
+    def test_invalid_task_event(self):
+        """Test the handle_task_event handler with an invalid task event."""
+        task_event = "unknown-task-event"
+        event = {"type": task_event, "hostname": self.hostname, "uuid": self.event_uuid}
+        celery_metrics.state = MagicMock()
+
+        with self.assertLogs("internal.metrics", level="WARNING") as logging_watcher:
+            celery_metrics.handle_task_event(event)
+
+        warn_messages = {
+            record.message
+            for record in logging_watcher.records
+            if record.levelname == "WARNING"
+        }
+
+        expected_info_message = f"No celery counter matches task state='{task_event}'"
+        self.assertIn(expected_info_message, warn_messages)
+
+    def test_task_succeeded_event(self):
+        """Test the handle_task_event handler for a succeeded task event."""
+        event = {
+            "type": "task-succeeded",
+            "hostname": self.hostname,
+            "uuid": self.event_uuid,
+        }
+        task_succeeded_counter = MagicMock(labels=MagicMock())
+        task_runtime_histogram = MagicMock(labels=MagicMock())
+        celery_metrics.state_counters = {"task-succeeded": task_succeeded_counter}
+        celery_metrics.celery_task_runtime = task_runtime_histogram
+        self.task.runtime = 1000
+        tasks = {self.event_uuid: self.task}
+        celery_metrics.state = MagicMock(tasks=tasks)
+        celery_metrics.handle_task_event(event)
+        task_succeeded_counter.labels.assert_called_with(
+            name=self.task_name, hostname=self.hostname
+        )
+        task_succeeded_counter.labels.return_value.inc.assert_called_with()
+        task_runtime_histogram.labels.assert_called_with(
+            name=self.task_name, hostname=self.hostname
+        )
+        task_runtime_histogram.labels.return_value.observe.assert_called_with(
+            self.task.runtime
+        )
+
+    def test_task_failed_event(self):
+        """Test the handle_task_event handler for a failed task event."""
+        event = {
+            "type": "task-failed",
+            "hostname": self.hostname,
+            "uuid": self.event_uuid,
+        }
+        task_failed_counter = MagicMock(labels=MagicMock())
+        celery_metrics.state_counters = {"task-failed": task_failed_counter}
+        self.task.exception = "SomeException(Some Error)"
+        tasks = {self.event_uuid: self.task}
+        celery_metrics.state = MagicMock(tasks=tasks)
+        celery_metrics.handle_task_event(event)
+        task_failed_counter.labels.assert_called_with(
+            name=self.task_name, hostname=self.hostname, exception="SomeException"
+        )
+        task_failed_counter.labels.return_value.inc.assert_called_with()
+
+    def test_worker_heartbeat(self):
+        """Test the handle_worker_heartbeat handler."""
+        event = {"type": "worker-heartbeat", "hostname": self.hostname}
+        worker_up_gauge = MagicMock(labels=MagicMock())
+        tasks_active_gauge = MagicMock(labels=MagicMock())
+        celery_metrics.celery_worker_up = worker_up_gauge
+        celery_metrics.celery_tasks_active = tasks_active_gauge
+        celery_metrics.state = MagicMock(return_value=[[MagicMock(active=1)]])
+        celery_metrics.handle_worker_heartbeat(event)
+        worker_up_gauge.labels.assert_called_with(hostname=self.hostname)
+        worker_up_gauge.labels.return_value.set.assert_any_call(1)
+
+    def test_worker_online_status(self):
+        """Test the handle_worker_status handler for worker-online."""
+        event = {"hostname": self.hostname}
+        worker_up_gauge = MagicMock(labels=MagicMock())
+        celery_metrics.celery_worker_up = worker_up_gauge
+        celery_metrics.handle_worker_status(event, 1)
+        worker_up_gauge.labels.assert_called_with(hostname=self.hostname)
+        worker_up_gauge.labels.return_value.set.assert_any_call(1)
+
+    def test_worker_offline_status(self):
+        """Test the handle_worker_status handler for worker-offline."""
+        event = {"hostname": self.hostname}
+        worker_up_gauge = MagicMock(labels=MagicMock())
+        celery_metrics.celery_worker_up = worker_up_gauge
+        celery_metrics.handle_worker_status(event, 0)
+        worker_up_gauge.labels.assert_called_with(hostname=self.hostname)
+        worker_up_gauge.labels.return_value.set.assert_any_call(0)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1240,7 +1240,7 @@ tabulate = "*"
 
 [[package]]
 name = "kombu"
-version = "5.2.3"
+version = "5.2.4"
 description = "Messaging library for Python."
 category = "main"
 optional = false
@@ -1947,7 +1947,7 @@ python-versions = "*"
 name = "pywin32"
 version = "303"
 description = "Python for Window Extensions"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -2412,7 +2412,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "8ffb1b94efc3897d3034a07f04ad78cc480be3292f4cf26b50393fa18d28cffc"
+content-hash = "f0ad59adc226a1a1508766fe6fbbfc1daea7bf4f07565f9f448d8abd0e6de920"
 
 [metadata.files]
 adal = [
@@ -2968,8 +2968,8 @@ knack = [
     {file = "knack-0.9.0.tar.gz", hash = "sha256:7fcab17585c0236885eaef311c01a1e626d84c982aabcac81703afda3f89c81f"},
 ]
 kombu = [
-    {file = "kombu-5.2.3-py3-none-any.whl", hash = "sha256:eeaeb8024f3a5cfc71c9250e45cddb8493f269d74ada2f74909a93c59c4b4179"},
-    {file = "kombu-5.2.3.tar.gz", hash = "sha256:81a90c1de97e08d3db37dbf163eaaf667445e1068c98bfd89f051a40e9f6dbbd"},
+    {file = "kombu-5.2.4-py3-none-any.whl", hash = "sha256:8b213b24293d3417bcf0d2f5537b7f756079e3ea232a8386dcc89a59fd2361a4"},
+    {file = "kombu-5.2.4.tar.gz", hash = "sha256:37cee3ee725f94ea8bb173eaab7c1760203ea53bbebae226328600f9d2799610"},
 ]
 kubernetes = [
     {file = "kubernetes-22.6.0-py2.py3-none-any.whl", hash = "sha256:5d329ee9b40e333e32f7bb62339cdce3eac47ab7c50b305ec21c114c49447e20"},
@@ -3205,11 +3205,6 @@ psutil = [
     {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
     {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
     {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
-    {file = "psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56"},
-    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203"},
-    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d"},
-    {file = "psutil-5.9.0-cp36-cp36m-win32.whl", hash = "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64"},
-    {file = "psutil-5.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94"},
     {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ azure-mgmt-resource = "^19.0.0"
 azure-cli-core = "^2.27.2"
 django-prometheus = "~=2.1.0"
 redis = "^4.1.0"
+kombu = "^5.2.4"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- Based on celery-exporter
- Exposed as part of /internal/metrics
- Celery metrics listener in a separate thread

For https://github.com/cloudigrade/cloudigrade/issues/1118

### Metrics
Name     | Description | Type
---------|-------------|----
celery_task_sent_total | Sent when a task message is published. | Counter
celery_task_received_total | Sent when the worker receives a task. | Counter
celery_task_started_total | Sent just before the worker executes the task. | Counter
celery_task_succeeded_total | Sent if the task executed successfully. | Counter
celery_task_failed_total | Sent if the execution of the task failed. | Counter
celery_task_rejected_total | The task was rejected by the worker, possibly to be re-queued or moved to a dead letter queue. | Counter
celery_task_revoked_total | Sent if the task has been revoked. | Counter
celery_task_retried_total | Sent if the task failed, but will be retried in the future. | Counter
celery_worker_up | Indicates if a worker has recently sent a heartbeat. | Gauge
celery_worker_tasks_active | The number of tasks the worker is currently processing | Gauge
celery_task_runtime | Histogram of runtime measurements for each task | Histogram