### PR TITLE
1159 houndilogs

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/inspection.py
+++ b/cloudigrade/api/clouds/aws/tasks/inspection.py
@@ -122,14 +122,14 @@ def _build_cloud_init_script(ami_id):
                             "log_group_name": f"houndigrade-"
                             f"{settings.CLOUDIGRADE_ENVIRONMENT}",
                             "log_stream_name": f"{ami_id}-inspection",
-                            "retention_in_days": 14,
+                            "retention_in_days": settings.HOUNDIGRADE_CW_RETENTION_DAYS,
                         },
                         {
                             "file_path": "/var/log/messages",
                             "log_group_name": f"houndigrade-"
                             f"{settings.CLOUDIGRADE_ENVIRONMENT}",
                             "log_stream_name": f"{ami_id}-system",
-                            "retention_in_days": 14,
+                            "retention_in_days": settings.HOUNDIGRADE_CW_RETENTION_DAYS,
                         },
                     ]
                 }

--- a/cloudigrade/api/migrations/0056_alter_syntheticdatarequest_expires_at.py
+++ b/cloudigrade/api/migrations/0056_alter_syntheticdatarequest_expires_at.py
@@ -7,13 +7,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('api', '0055_syntheticdatarequest'),
+        ("api", "0055_syntheticdatarequest"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='syntheticdatarequest',
-            name='expires_at',
-            field=models.DateTimeField(default=api.models.syntheticdatarequest_expires_at_default),
+            model_name="syntheticdatarequest",
+            name="expires_at",
+            field=models.DateTimeField(
+                default=api.models.syntheticdatarequest_expires_at_default
+            ),
         ),
     ]

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -383,6 +383,7 @@ AWS_SQS_MAX_YIELD_COUNT = env.int("AWS_SQS_MAX_YIELD_COUNT", default=25)
 #####################################################################
 # Configs used for running houndigrade and accessing its results
 
+HOUNDIGRADE_CW_RETENTION_DAYS = env.int("HOUNDIGRADE_CW_RETENTION_DAYS", default=90)
 HOUNDIGRADE_ECS_IMAGE_NAME = env(
     "HOUNDIGRADE_ECS_IMAGE_NAME", default="cloudigrade/houndigrade"
 )

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -170,6 +170,8 @@ objects:
           value: ${CLOUDIGRADE_LOG_LEVEL}
         - name: SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY
           value: ${SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY}
+        - name: HOUNDIGRADE_CW_RETENTION_DAYS
+          value: ${HOUNDIGRADE_CW_RETENTION_DAYS}
         - name: HOUNDIGRADE_ECS_IMAGE_NAME
           value: ${HOUNDIGRADE_ECS_IMAGE_NAME}
         - name: HOUNDIGRADE_ECS_IMAGE_TAG
@@ -439,6 +441,8 @@ objects:
           value: ${SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY}
         - name: DJANGO_CONSOLE_LOG_LEVEL
           value: ${DJANGO_CONSOLE_LOG_LEVEL}
+        - name: HOUNDIGRADE_CW_RETENTION_DAYS
+          value: ${HOUNDIGRADE_CW_RETENTION_DAYS}
         - name: HOUNDIGRADE_ECS_IMAGE_NAME
           value: ${HOUNDIGRADE_ECS_IMAGE_NAME}
         - name: HOUNDIGRADE_ECS_IMAGE_TAG
@@ -716,6 +720,8 @@ objects:
           value: ${CLOUDIGRADE_LOG_LEVEL}
         - name: SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY
           value: ${SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY}
+        - name: HOUNDIGRADE_CW_RETENTION_DAYS
+          value: ${HOUNDIGRADE_CW_RETENTION_DAYS}
         - name: HOUNDIGRADE_ECS_IMAGE_NAME
           value: ${HOUNDIGRADE_ECS_IMAGE_NAME}
         - name: HOUNDIGRADE_ECS_IMAGE_TAG
@@ -990,6 +996,8 @@ objects:
           value: ${CLOUDIGRADE_LOG_LEVEL}
         - name: SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY
           value: ${SCHEDULE_CONCURRENT_USAGE_CALCULATION_DELAY}
+        - name: HOUNDIGRADE_CW_RETENTION_DAYS
+          value: ${HOUNDIGRADE_CW_RETENTION_DAYS}
         - name: HOUNDIGRADE_ECS_IMAGE_NAME
           value: ${HOUNDIGRADE_ECS_IMAGE_NAME}
         - name: HOUNDIGRADE_ECS_IMAGE_TAG
@@ -1673,6 +1681,10 @@ parameters:
   displayName: Health Check Host Header
   required: true
   value: health.cloudigrade.insights.openshiftapps.com
+- name: HOUNDIGRADE_CW_RETENTION_DAYS
+  displayName: How long should cloudigrade inspection logs be stored in cloudwatch
+  required: true
+  value: '90'
 - name: HOUNDIGRADE_ECS_FAMILY_NAME
   displayName: AWS Houndigrade ECS Image Tag
   required: true

--- a/deployment/playbooks/roles/aws/defaults/main.yml
+++ b/deployment/playbooks/roles/aws/defaults/main.yml
@@ -6,44 +6,6 @@ ecs_state: "absent"
 ec2_state: "present"
 s3_state: "present"
 
-### ecs.yml
-# ECS Resource Names
-ecs_cluster_name: cloudigrade-ecs-{{env}}
-ecs_iam_role_name: cloudigrade-ecs-role-{{env}}
-ecs_iam_policy_name: cloudigrade-ecs-policy-{{env}}
-ec2_ssh_key_name: cloudigrade-ecs-ssh-{{env}}
-ec2_sg_name: cloudigrade-sg-{{env}}
-ec2_lc_name: cloudigrade-lc-{{env}}
-ec2_asg_name: cloudigrade-ecs-asg-{{env}}
-
-# EC2 LC Defaults
-ec2_instance_monitoring: true
-ec2_instance_type: "t2.micro"
-recommended_ami: "{{ lookup('aws_ssm', '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended', shortnames=true, bypath=true ) }}"
-# Needed to register the EC2 instance with ECS
-# https://aws.amazon.com/premiumsupport/knowledge-center/execute-user-data-ec2/
-ec2_userdata: |
-  Content-Type: multipart/mixed; boundary="//"
-  MIME-Version: 1.0
-
-  --//
-  MIME-Version: 1.0
-  Content-Type: text/x-shellscript; charset="us-ascii"
-
-  #!/bin/bash
-
-  # Set cluster name in ECS config
-  echo ECS_CLUSTER={{ ecs_cluster_name }} >> /etc/ecs/ecs.config;
-  --//
-
-# ECS ASG Defaults
-ec2_asg_az: "us-east-1a"
-ec2_asg_min_size: 0
-ec2_asg_max_size: 0
-ec2_asg_desired_capacity: 0
-ec2_asg_replace_all_instances: yes
-
-
 ### ec2.yml
 # EC2 LT Defaults
 ec2_lt_name: "cloudigrade-lt-{{env}}"
@@ -54,6 +16,12 @@ ec2_lt_instance_monitoring: true
 ec2_lt_instance_type: "t2.micro"
 ec2_lt_recommended_ami: "{{ lookup('aws_ssm', '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended', shortnames=true, bypath=true ) }}"
 
+# EC2 LC Defaults
+ec2_ssh_key_name: cloudigrade-ecs-ssh-{{env}}
+ec2_sg_name: cloudigrade-sg-{{env}}
+ec2_instance_monitoring: true
+ec2_instance_type: "t2.micro"
+recommended_ami: "{{ lookup('aws_ssm', '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended', shortnames=true, bypath=true ) }}"
 
 ### s3.yml
 # Names

--- a/deployment/playbooks/roles/aws/defaults/main.yml
+++ b/deployment/playbooks/roles/aws/defaults/main.yml
@@ -11,7 +11,6 @@ s3_state: "present"
 ecs_cluster_name: cloudigrade-ecs-{{env}}
 ecs_iam_role_name: cloudigrade-ecs-role-{{env}}
 ecs_iam_policy_name: cloudigrade-ecs-policy-{{env}}
-ecs_cloudwatch_iam_policy_name: cloudigrade-cloudwatch-policy-{{env}}
 ec2_ssh_key_name: cloudigrade-ecs-ssh-{{env}}
 ec2_sg_name: cloudigrade-sg-{{env}}
 ec2_lc_name: cloudigrade-lc-{{env}}
@@ -49,6 +48,7 @@ ec2_asg_replace_all_instances: yes
 # EC2 LT Defaults
 ec2_lt_name: "cloudigrade-lt-{{env}}"
 ec2_lt_policy_name: "{{ec2_lt_name}}-policy"
+ec2_cw_policy_name: "{{ec2_lt_name}}-cw-policy"
 ec2_lt_role_name: "{{ec2_lt_name}}-role"
 ec2_lt_instance_monitoring: true
 ec2_lt_instance_type: "t2.micro"

--- a/deployment/playbooks/roles/aws/files/cloudwatch-policy.json
+++ b/deployment/playbooks/roles/aws/files/cloudwatch-policy.json
@@ -4,14 +4,14 @@
         {
             "Effect": "Allow",
             "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
+                "logs:PutRetentionPolicy",
                 "logs:PutLogEvents",
-                "logs:DescribeLogStreams"
+                "logs:DescribeLogStreams",
+                "logs:DescribeLogGroups",
+                "logs:CreateLogStream",
+                "logs:CreateLogGroup"
             ],
-            "Resource": [
-                "arn:aws:logs:*:*:*"
-            ]
+            "Resource": "*"
         }
     ]
 }

--- a/deployment/playbooks/roles/aws/tasks/ec2.yml
+++ b/deployment/playbooks/roles/aws/tasks/ec2.yml
@@ -28,6 +28,13 @@
       policy_name: "{{ec2_lt_policy_name}}"
       policy_json: "{{ lookup( 'template', 'ec2_houndigrade_put_policy.json.j2') | to_json }}"
 
+  - name: create / ec2 cloud watch policy
+    iam_policy:
+      iam_name: "{{ec2_lt_role_name}}"
+      iam_type: role
+      policy_name: "{{ec2_cw_policy_name}}"
+      policy_json: "{{ lookup('file','cloudwatch-policy.json') }}"
+
   - name: create / ec2 launch template
     ec2_launch_template:
       name: "{{ec2_lt_name}}"


### PR DESCRIPTION
#1159 

Demo: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/houndigrade-ephemeral-ephemeral-thtgmh (in the same account as before)

Logs are split into two files, for readability. All houndigrade inspection logs are in the -inspection stream, the content of /var/log/messages is in -system. Retention period is 14 days.