### PR TITLE
add env var OSD_REDEPLOY_TRIGGER to metrics deployment

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -858,6 +858,8 @@ objects:
           value: ${CELERY_METRICS_RETRY_INTERVAL}
         - name: CLOUDIGRADE_ENVIRONMENT
           value: ${CLOUDIGRADE_ENVIRONMENT}
+        - name: OSD_REDEPLOY_TRIGGER
+          value: ${OSD_REDEPLOY_TRIGGER}
     - name: worker
       #
       # Component cloudigrade-worker deployment:


### PR DESCRIPTION
Since we aren't granted permission to restart pods directly, and trying to get an IC on the line to troubleshoot is a pain, I'm adding the kludgy and otherwise *completely unused* variable to the metrics deployment so we can force pods to restart by making a trivial config change.

We already had this on our old deployment configs, and I *think* it still works, though I haven't used it recently.