### PR TITLE
add InsufficientDependencyServiceAccessPermissionException to COMMON_AWS_ACCESS_DENIED_ERROR_CODES

### DIFF
--- a/cloudigrade/util/aws/helper.py
+++ b/cloudigrade/util/aws/helper.py
@@ -25,6 +25,7 @@ COMMON_AWS_ACCESS_DENIED_ERROR_CODES = (
     "AccessDenied",
     "AccessDeniedException",
     "AuthFailure",
+    "InsufficientDependencyServiceAccessPermissionException",
     "OptInRequired",
     "UnauthorizedOperation",
 )


### PR DESCRIPTION
We've very recently started seeing this error from some AWS accounts.

I suspect this may be related to the accounts that have customer-managed keys encrypting their CloudTrail logs.

See also: https://sentry.io/organizations/cloudigrade/issues/2413943885/?project=1270362