### PR TITLE
update default config values for DJANGO_SENTRY_SAMPLE_RATE_DEFAULT and DJANGO_SENTRY_SAMPLE_RATE_BY_VIEW_NAME

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1671,11 +1671,17 @@ parameters:
 - name: DJANGO_SENTRY_SAMPLE_RATE_DEFAULT
   displayName: Default Sentry performance sample rate for Django HTTP APIs
   required: true
-  value: '0.5'
+  value: '0.1'
 - name: DJANGO_SENTRY_SAMPLE_RATE_BY_VIEW_NAME
   displayName: Sentry performance sample rates for specific Djando view names
   required: true
-  value: '{"v2-sysconfig-list": 0.1, "health_check:health_check_home": 0.0}'
+  value: |
+    {
+    "v2-concurrent-list":0.01,
+    "internal-availability-status":0.02,
+    "health_check:health_check_home":0.0,
+    "prometheus-django-metrics":0.0
+    }
 - name: DJANGO_SETTINGS_MODULE
   displayName: Django Settings Module
   required: true


### PR DESCRIPTION
We've made the same changes in app-interface overrides for both stage and production. So, let's just make this the default and simplify the app-interface overrides.

- app-interface stage override: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/cloudigrade/cicd/deploy-clowder.yml#L70
- app-interface prod override: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/cloudigrade/cicd/deploy-clowder.yml#L117