### PR TITLE
handle "s3:TestEvent" messages encountered among inspection results

### DIFF
--- a/cloudigrade/api/tests/tasks/inspection/test_persist_inspection_cluster_results_task.py
+++ b/cloudigrade/api/tests/tasks/inspection/test_persist_inspection_cluster_results_task.py
@@ -3,10 +3,13 @@ import json
 import uuid
 from unittest.mock import patch
 
+import faker
 from django.test import TestCase
 
 from api.tasks import inspection
 from util.tests import helper as util_helper
+
+_faker = faker.Faker()
 
 
 class PersistInspectionClusterResultsTaskTest(TestCase):
@@ -150,6 +153,61 @@ class PersistInspectionClusterResultsTaskTest(TestCase):
         self.assertEqual(sqs_message.body, s[0]["body"])
         self.assertEqual([], f)
 
+    @patch("util.aws.delete_messages_from_queue")
+    @patch("util.aws.yield_messages_from_queue")
+    @patch("util.aws.get_sqs_queue_url")
+    @patch("api.tasks.inspection.persist_aws_inspection_cluster_results")
+    def test_persist_inspect_results_s3_testevent_log_and_delete(
+        self, mock_persist, _, mock_receive, mock_delete
+    ):
+        """Assert an s3:TestEvent message is simply logged and deleted."""
+        receipt_handle = str(uuid.uuid4())
+        message_id = str(uuid.uuid4())
+        message_body = util_helper.generate_dummy_s3_testevent_message()
+        sqs_message = util_helper.generate_mock_sqs_message(
+            message_id, message_body, receipt_handle
+        )
+        mock_receive.return_value = [sqs_message]
+        with self.assertLogs("api.tasks.inspection", level="INFO") as logging_watcher:
+            inspection.persist_inspection_cluster_results_task()
+        self.assertEqual(
+            logging_watcher.records[-2].message,
+            f"s3:TestEvent message received: {message_body}",
+        )
+        self.assertEqual(
+            logging_watcher.records[-1].message, "No inspection results found."
+        )
+        mock_persist.assert_not_called()
+        mock_delete.assert_called_once()
+
+    @patch("util.aws.delete_messages_from_queue")
+    @patch("util.aws.yield_messages_from_queue")
+    @patch("util.aws.get_sqs_queue_url")
+    @patch("api.tasks.inspection.persist_aws_inspection_cluster_results")
+    def test_persist_inspect_results_mystery_message_logged(
+        self, mock_persist, _, mock_receive, mock_delete
+    ):
+        """Assert mysterious message with no inspection results is simply logged."""
+        receipt_handle = str(uuid.uuid4())
+        message_id = str(uuid.uuid4())
+        message_body = f'{{"{_faker.slug()}":"{_faker.slug()}"}}'
+        sqs_message = util_helper.generate_mock_sqs_message(
+            message_id, message_body, receipt_handle
+        )
+        mock_receive.return_value = [sqs_message]
+        with self.assertLogs("api.tasks.inspection", level="INFO") as logging_watcher:
+            inspection.persist_inspection_cluster_results_task()
+        self.assertEqual(
+            f"No inspection results found for SQS message: {message_body}",
+            logging_watcher.records[-2].message,
+        )
+        self.assertEqual("ERROR", logging_watcher.records[-2].levelname)
+        self.assertEqual(
+            "No inspection results found.", logging_watcher.records[-1].message
+        )
+        mock_persist.assert_not_called()
+        mock_delete.assert_not_called()
+
     @patch("api.tasks.inspection.aws")
     def test_fetch_inspection_results_success(self, mock_aws):
         """Assert we correctly fetch results from provided bucket and key."""
@@ -170,3 +228,18 @@ class PersistInspectionClusterResultsTaskTest(TestCase):
         mock_extract_messages.assert_called_once_with(mock_message)
         mock_get_object.assert_called_once_with(mock_bucket_name, mock_key)
         self.assertEqual(json.loads(mock_inspection_dict), results[0])
+
+    def test_is_s3_testevent_message_true(self):
+        """Assert we correctly identify an s3:TestEvent message."""
+        message = util_helper.generate_dummy_s3_testevent_message()
+        self.assertTrue(inspection._is_s3_testevent_message(message))
+
+    def test_is_s3_testevent_message_false(self):
+        """Assert we correctly identify a not-s3:TestEvent message."""
+        message = f'{{"Service":"{_faker.slug()}","Event":"{_faker.slug()}"}}'
+        self.assertFalse(inspection._is_s3_testevent_message(message))
+
+    def test_is_s3_testevent_message_false_because_exception(self):
+        """Assert non-JSON message is not identified as an s3:TestEvent message."""
+        message = str(uuid.uuid4())  # Not valid JSON, would internally raise exception.
+        self.assertFalse(inspection._is_s3_testevent_message(message))

--- a/cloudigrade/util/tests/helper.py
+++ b/cloudigrade/util/tests/helper.py
@@ -414,6 +414,18 @@ def generate_dummy_aws_cloud_account_post_data():
     return data
 
 
+def generate_dummy_s3_testevent_message():
+    """Generate a fake s3:TestEvent message for testing."""
+    return (
+        '{"Service":"Amazon S3","Event":"s3:TestEvent",'
+        f'"Time":"{_faker.iso8601(timespec="milliseconds")}Z",'
+        f'"Bucket":"{_faker.slug()}","RequestId":"'
+        f'{_faker.password(length=16, special_chars=False, lower_case=False)}",'
+        f'"HostId":"{base64.b64encode(_faker.binary(length=56)).decode("utf-8")}"'
+        "}"
+    )
+
+
 def generate_dummy_azure_cloud_account_post_data():
     """
     Generate all post data needed for creating an AzureCloudAccount.


### PR DESCRIPTION
As recently discussed [here in Slack](https://ansible.slack.com/archives/C8VGAPJNN/p1655317385540179), we found a growing number of messages on the inspection results DLQ, indicating that we were failing to process some messages. It turns out they are all test messages from AWS itself.

> A week ago was when HPAs came online, and we started seeing a lot more pods come and go with CPU load changes. When an API pod starts, its init container runs `cloudigrade_init.sh` which runs our Ansible playbook `manage-cloudigrade.yml` which ensures that our AWS resources are defined appropriately, and that includes this S3-SQS notification config.
> 
> I checked [#cloudmeter-deployments](https://ansible.slack.com/archives/C01PB2C711V) and the times for all recent prod messages correlate _very strongly_ with the times in these messages. I think that's our connection: every time an API pod starts, the init container runs, AWS configs refresh, and AWS sends a test message _even if the configs don't actually change_.
>
> Aside from looking a broken alarm, this isn't causing any major problems, but I'm going to code something into our message processing now anyway so that these don't mask any real problems in the future (and since it's all fresh in my mind).

Let's simply log a message and delete these message when we encounter them.