### PR TITLE
Enable Django caching with Redis.

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -82,6 +82,7 @@ THIRD_PARTY_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_prometheus",
+    "django_redis",
     "generic_relations",
     "health_check",
     "health_check.db",

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -82,6 +82,7 @@ THIRD_PARTY_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_prometheus",
+    "django_redis",
     "generic_relations",
     "health_check",
     "health_check.db",
@@ -567,12 +568,24 @@ DELETE_INACTIVE_USERS_MIN_AGE = env.int(
     "DELETE_INACTIVE_USERS_MIN_AGE", default=60 * 60 * 24
 )
 
+#####################################################################
+# Django caching
+
 # Cache ttl settings
 CACHE_TTL_DEFAULT = env.int("CACHE_TTL_DEFAULT", default=60)
 
 CACHE_TTL_SOURCES_APPLICATION_TYPE_ID = env.int(
     "CACHE_TTL_SOURCES_APPLICATION_TYPE_ID", default=CACHE_TTL_DEFAULT
 )
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_URL,
+        "KEY_PREFIX": f"{CLOUDIGRADE_ENVIRONMENT}-cloudigrade",
+        "TIMEOUT": CACHE_TTL_DEFAULT,
+    }
+}
 
 # How far back should we look for related data when recalculating runs
 RECALCULATE_RUNS_SINCE_DAYS_AGO = env.int("RECALCULATE_RUNS_SINCE_DAYS_AGO", default=3)

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -82,7 +82,6 @@ THIRD_PARTY_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_prometheus",
-    "django_redis",
     "generic_relations",
     "health_check",
     "health_check.db",

--- a/cloudigrade/config/settings/test.py
+++ b/cloudigrade/config/settings/test.py
@@ -18,3 +18,11 @@ logging.config.dictConfig(LOGGING)
 
 # Always enable SyntheticDataRequest HTTP API for tests.
 ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API = True
+
+# We never want to interact with a real Redis cache server during unit tests.
+# Override the Redis server configured in `base.py` with the in-memory cache.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}

--- a/cloudigrade/internal/tests/views/test_cache.py
+++ b/cloudigrade/internal/tests/views/test_cache.py
@@ -39,7 +39,21 @@ class CacheViewTest(TestCase):
 
         response = cache_keys(request, key)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, value)
+        self.assertEqual(response.data["value"], value)
+
+    def test_cache_get_success_with_timeout(self):
+        """Test get of a key returns the key, its value and timeout."""
+        key = _faker.word()
+        value = _faker.slug()
+        timeout = _faker.random_int(min=600, max=3600)
+        cache.set(key, value, timeout)
+        request = self.factory.get(f"/cache/{key}")
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["key"], key)
+        self.assertEqual(response.data["value"], value)
+        self.assertTrue(timeout - 2 <= response.data["timeout"] <= timeout)
 
     def test_cache_set_missing_value(self):
         """Test cache set with missing value."""

--- a/cloudigrade/internal/tests/views/test_cache.py
+++ b/cloudigrade/internal/tests/views/test_cache.py
@@ -1,0 +1,73 @@
+"""Collection of tests for Internal cache."""
+from unittest.mock import patch
+
+import faker
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from internal.views import cache_keys
+
+_faker = faker.Faker()
+
+
+class CacheViewTest(TestCase):
+    """Cache View test case."""
+
+    def setUp(self):
+        """Set up a bunch shared test data."""
+        self.factory = APIRequestFactory()
+
+    def test_cache_set_success(self):
+        """Test happy path success for setting a cache key."""
+        key = _faker.word()
+        value = _faker.slug()
+        request = self.factory.post(
+            f"/cache/{key}", data={"value": value}, format="json"
+        )
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(cache.get(key), value)
+
+    def test_cache_get_success(self):
+        """Test happy path success for getting a cache key."""
+        key = _faker.word()
+        value = _faker.slug()
+        cache.set(key, value)
+        request = self.factory.get(f"/cache/{key}")
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, value)
+
+    def test_cache_set_missing_value(self):
+        """Test cache set with missing value."""
+        key = _faker.word()
+        request = self.factory.post(f"/cache/{key}", data={}, format="json")
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0], "value field is required")
+
+    def test_cache_get_invalid_key(self):
+        """Test get of an invalid key returns a 404."""
+        key = _faker.word()
+        request = self.factory.get(f"/cache/{key}")
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 404)
+
+    @patch("django.core.cache.cache.set")
+    def test_cache_set_timeout_honored(self, mock_cache):
+        """Test set of a key with timeout is honored."""
+        key = _faker.word()
+        value = _faker.slug()
+        timeout = _faker.random_int(min=600, max=3600)
+        request = self.factory.post(
+            f"/cache/{key}", data={"value": value, "timeout": timeout}, format="json"
+        )
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 200)
+        mock_cache.assert_called_with(key, value, timeout=timeout)

--- a/cloudigrade/internal/urls.py
+++ b/cloudigrade/internal/urls.py
@@ -103,6 +103,7 @@ urlpatterns += [
 
 # URL patterns for potentially-destructive custom commands.
 urlpatterns += [
+    path("cache/<str:key>/", views.cache_keys, name="internal-cache"),
     path(
         "delete_cloud_accounts_not_in_sources/",
         views.delete_cloud_accounts_not_in_sources,

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -24,6 +24,7 @@ from internal.authentication import (
     IdentityHeaderAuthenticationInternal,
 )
 from util import exceptions as util_exceptions
+from util.cache import get_cache_key_timeout
 from util.redhatcloud import identity
 
 logger = logging.getLogger(__name__)
@@ -321,7 +322,12 @@ def cache_keys(request, key):
         if not value:
             raise Http404
         else:
-            return Response(content_type="text/plain", data=value)
+            data = {
+                "key": key,
+                "value": value,
+                "timeout": get_cache_key_timeout(key),
+            }
+            return Response(data=data)
     elif method == "post":
         """Post a single cache key."""
         value = request.data.get("value")

--- a/cloudigrade/util/cache.py
+++ b/cloudigrade/util/cache.py
@@ -1,0 +1,24 @@
+"""Collection of helper methods for the Internal caching."""
+import datetime
+
+from django.core.cache import cache, caches
+from django_redis.cache import RedisCache
+
+
+def get_cache_key_timeout(key):
+    """Return the timeout for the key specified."""
+    # Development/Production environments use Redis
+    if isinstance(caches["default"], RedisCache):
+        return cache.ttl(key=key)
+
+    # Test environments use LocMemCache
+    expiration_unix_timestamp = cache._expire_info.get(cache.make_key(key))
+    if expiration_unix_timestamp is None:
+        return 0
+    expiration_date_time = datetime.datetime.fromtimestamp(expiration_unix_timestamp)
+
+    now = datetime.datetime.now()
+    if expiration_date_time < now:
+        return 0
+    delta = expiration_date_time - now
+    return delta.seconds

--- a/cloudigrade/util/tests/redhatcloud/test_sources.py
+++ b/cloudigrade/util/tests/redhatcloud/test_sources.py
@@ -151,7 +151,7 @@ class SourcesTest(TestCase):
         )
         self.assertEqual(response_app_type_id, cloudigrade_app_type_id)
 
-        """Call it again and make sure the original, cached value is returened"""
+        """Call it again and make sure the original, cached value is returned"""
         not_cloudigrade_app_type_id = _faker.pyint()
         not_expected = {"data": [{"id": not_cloudigrade_app_type_id}]}
         mock_get.return_value.json.return_value = not_expected

--- a/poetry.lock
+++ b/poetry.lock
@@ -819,6 +819,21 @@ python-versions = "*"
 prometheus-client = ">=0.7"
 
 [[package]]
+name = "django-redis"
+version = "5.2.0"
+description = "Full featured redis cache backend for Django."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Django = ">=2.2"
+redis = ">=3,<4.0.0 || >4.0.0,<4.0.1 || >4.0.1"
+
+[package.extras]
+hiredis = ["redis[hiredis] (>=3,!=4.0.0,!=4.0.1)"]
+
+[[package]]
 name = "django-timezone-field"
 version = "5.0"
 description = "A Django app providing DB, form, and REST framework fields for zoneinfo and pytz timezone objects."
@@ -2035,7 +2050,7 @@ python-versions = "*"
 name = "pywin32"
 version = "304"
 description = "Python for Window Extensions"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -2522,7 +2537,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e5b3a9eeaeb2f0efad798a6f0ad1df23714e2e04d2835ba6158150d2b07ef7e4"
+content-hash = "b66fefda0b9d89db9b6fc3cd0bd253fa332a9707d4778ca466ca422d3c827c80"
 
 [metadata.files]
 adal = [
@@ -2960,6 +2975,10 @@ django-model-utils = [
 django-prometheus = [
     {file = "django-prometheus-2.2.0.tar.gz", hash = "sha256:240378a1307c408bd5fc85614a3a57f1ce633d4a222c9e291e2bbf325173b801"},
     {file = "django_prometheus-2.2.0-py2.py3-none-any.whl", hash = "sha256:e6616770d8820b8834762764bf1b76ec08e1b98e72a6f359d488a2e15fe3537c"},
+]
+django-redis = [
+    {file = "django-redis-5.2.0.tar.gz", hash = "sha256:8a99e5582c79f894168f5865c52bd921213253b7fd64d16733ae4591564465de"},
+    {file = "django_redis-5.2.0-py3-none-any.whl", hash = "sha256:1d037dc02b11ad7aa11f655d26dac3fb1af32630f61ef4428860a2e29ff92026"},
 ]
 django-timezone-field = [
     {file = "django-timezone-field-5.0.tar.gz", hash = "sha256:15746ed367a5a32eda76cfa2886eeec1de8cda79f519b7c5e12f87ed7cdbd663"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ azure-mgmt-resource = "^21.0.0"
 azure-cli-core = "^2.32.0"
 django-prometheus = "~=2.2.0"
 redis = "^4.2.2"
+django-redis = "^5.2.0"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Enable Django caching with Redis.
- include the django-redis package.
- enable the caching against redis using the configured redis host and auth.
- added internal /internal/cache endpoint to getting and setting key values.

For issue: https://github.com/cloudigrade/cloudigrade/issues/1221