### PR TITLE
Handle bogus Aws Account Id's in SQS message object keys

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/cloudtrail.py
+++ b/cloudigrade/api/clouds/aws/tasks/cloudtrail.py
@@ -266,9 +266,12 @@ def _parse_aws_account_id(key):
     r = re.match(r"^AWSLogs/(?P<aws_account_id>[^/]+)/.*$", key)
     if r:
         aws_account_id = r.group("aws_account_id")
-        is_valid = AwsCloudAccount.objects.filter(
-            aws_account_id=aws_account_id
-        ).exists()
+        try:
+            is_valid = AwsCloudAccount.objects.filter(
+                aws_account_id=aws_account_id
+            ).exists()
+        except Exception:
+            is_valid = False
         return aws_account_id, is_valid
     return None, False
 

--- a/cloudigrade/api/tests/clouds/aws/tasks/cloudtrail/test_analyze_log.py
+++ b/cloudigrade/api/tests/clouds/aws/tasks/cloudtrail/test_analyze_log.py
@@ -855,6 +855,64 @@ class AnalyzeLogTest(TestCase):
         self.assertEqual(len(images), 0)
 
     @patch("api.clouds.aws.tasks.cloudtrail.start_image_inspection")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.delete_messages_from_queue")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.get_object_content_from_s3")
+    @patch("api.clouds.aws.tasks.cloudtrail.aws.yield_messages_from_queue")
+    def test_analyze_log_when_account_is_bogus(
+        self, mock_receive, mock_s3, mock_del, mock_inspection
+    ):
+        """
+        Test appropriate handling when the account ID in the log is bogus.
+
+        The net effect of this is that the extracted parts of the message related
+        to the unknown account return no new results, and the overall operation
+        completes successfully with no new objects written to the database.
+        """
+        bucket_name = "analyzer-test-bucket"
+        bogus_aws_account_id = "some-bogus-id"
+        object_key = f"AWSLogs/{bogus_aws_account_id}/path/to/file.gz"
+        sqs_message = helper.generate_mock_cloudtrail_sqs_message(
+            bucket_name=bucket_name,
+            object_key=object_key,
+        )
+        ec2_instance_id = util_helper.generate_dummy_instance_id()
+        trail_record = helper.generate_cloudtrail_instances_record(
+            aws_account_id=util_helper.generate_dummy_aws_account_id(),
+            instance_ids=[ec2_instance_id],
+        )
+        s3_content = {"Records": [trail_record]}
+        mock_receive.return_value = [sqs_message]
+        mock_s3.return_value = json.dumps(s3_content)
+
+        with self.assertLogs(
+            "api.clouds.aws.tasks.cloudtrail", level="INFO"
+        ) as logging_watcher:
+            successes, failures = tasks.analyze_log()
+
+        expected_message = (
+            f"Skipping reading CloudTrail log file from "
+            f"S3 bucket '{bucket_name}' key '{object_key}', "
+            f"invalid account number '{bogus_aws_account_id}' specified in key"
+        )
+
+        self.assertIn(
+            expected_message,
+            logging_watcher.records[0].message,
+        )
+
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(failures), 0)
+        mock_inspection.assert_not_called()
+        mock_del.assert_called()
+
+        instances = list(AwsInstance.objects.all())
+        self.assertEqual(len(instances), 0)
+        events = list(AwsInstanceEvent.objects.all())
+        self.assertEqual(len(events), 0)
+        images = list(AwsMachineImage.objects.all())
+        self.assertEqual(len(images), 0)
+
+    @patch("api.clouds.aws.tasks.cloudtrail.start_image_inspection")
     @patch("api.clouds.aws.tasks.cloudtrail.aws.get_session")
     @patch("api.clouds.aws.tasks.cloudtrail.aws.delete_messages_from_queue")
     @patch("api.clouds.aws.tasks.cloudtrail.aws.get_object_content_from_s3")


### PR DESCRIPTION
- Make sure we catch any exception when trying to search for AwsCloudAccount when filtering by aws_account_id.  Exceptions could represent malformed account id's i.e. bogus account id's in the AWSLogs/<bogus_id>/<path> object key.