### PR TITLE
Add overrides for DVO

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -328,12 +328,12 @@ objects:
       webServices:
         public:
           enabled: false
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-beat must only run with 1 replica"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         imagePullPolicy: Always
+        metadata:
+          annotations:
+            ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-beat must only run with 1 replica"
         command:
           - /bin/sh
           - -c
@@ -596,12 +596,12 @@ objects:
       webServices:
         public:
           enabled: false
-      metadata:
-        annotations:
-          ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-listener must only run with 1 replica"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         imagePullPolicy: Always
+        metadata:
+          annotations:
+            ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-listener must only run with 1 replica"
         command:
         - /bin/sh
         - -c

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -328,6 +328,9 @@ objects:
       webServices:
         public:
           enabled: false
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-beat must only run with 1 replica"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         imagePullPolicy: Always
@@ -593,6 +596,9 @@ objects:
       webServices:
         public:
           enabled: false
+      metadata:
+        annotations:
+          ignore-check.kube-linter.io/minimum-three-replicas: "cloudigrade-listener must only run with 1 replica"
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         imagePullPolicy: Always

--- a/deployment/stage-smoke.yaml
+++ b/deployment/stage-smoke.yaml
@@ -8,6 +8,9 @@ objects:
   kind: ClowdJobInvocation
   metadata:
     name: cloudigrade-smoke-${IMAGE_TAG}-${UID}
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods
   spec:
     appName: cloudigrade
     testing:


### PR DESCRIPTION
- Add override for DVO so that the minimum check of 3 replicas is not enforced for cloudigrade-beat
and cloudigrade-listener where they must run with just 1 replica.

For: https://github.com/cloudigrade/cloudigrade/issues/1232