### PR TITLE
make get_or_create_user handle legacy users that have no org_id

### DIFF
--- a/cloudigrade/api/authentication.py
+++ b/cloudigrade/api/authentication.py
@@ -126,7 +126,7 @@ def get_or_create_user(account_number, org_id):
     with transaction.atomic():
         if account_number and org_id:
             user, created = User.objects.get_or_create(
-                account_number=account_number, org_id=org_id
+                account_number=account_number, defaults={"org_id": org_id}
             )
         elif account_number:
             user, created = User.objects.get_or_create(account_number=account_number)

--- a/cloudigrade/api/tests/test_authenticate.py
+++ b/cloudigrade/api/tests/test_authenticate.py
@@ -396,6 +396,25 @@ class GetOrCreateUserMethodTests(TestCase):
         )
         self.assertEqual(user, self.user1)
 
+    def test_get_with_account_number_and_org_id_user_exists_with_only_account_number(
+        self,
+    ):
+        """
+        Test to get user object by account_number and org_id when one exists.
+
+        Unlike test_get_with_account_number_and_org_id, though, the existing user does
+        not have an org_id. This simulates the situation when we have an old user
+        but we failed to migrate and populate its org_id.
+        """
+        org_id = self.user1_org_id
+        self.user1.org_id = None
+        self.user1.save()
+        user = get_or_create_user(
+            account_number=self.user1_account_number, org_id=org_id
+        )
+        self.assertEqual(user, self.user1)
+        self.assertIsNone(self.user1.org_id)  # note that we didn't update it
+
     def test_get_with_account_number(self):
         """Test to get user object by account_number."""
         user = get_or_create_user(account_number=self.user2_account_number, org_id=None)


### PR DESCRIPTION
If we had an existing api.User with no org_id but called get_or_create_user with an org_id, the previous code would erroneously try to create a new api.User because it didn't expect that they could exist with no org_id. This change allows org_id to be missing during the get part of get_or_create.