### PR TITLE
restore "username" filtering on internal users api

### DIFF
--- a/cloudigrade/internal/filters.py
+++ b/cloudigrade/internal/filters.py
@@ -64,6 +64,21 @@ class InternalInstanceEventFilterSet(django_filters.FilterSet):
         }
 
 
+class InternalUserFilterSet(django_filters.FilterSet):
+    """FilterSet for limiting api.User for the internal API."""
+
+    username = django_filters.CharFilter(field_name="account_number")
+
+    class Meta:
+        model = models.User
+        fields = {
+            "account_number": ["exact"],
+            "date_joined": ["lt", "exact", "gt"],
+            "org_id": ["exact"],
+            "uuid": ["exact"],
+        }
+
+
 class InternalRunFilterSet(django_filters.FilterSet):
     """FilterSet for limiting Runs for the internal API."""
 

--- a/cloudigrade/internal/serializers.py
+++ b/cloudigrade/internal/serializers.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext as _
 from django_celery_beat.models import PeriodicTask
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField
+from rest_framework.fields import BooleanField, CharField
 from rest_framework.serializers import ModelSerializer
 
 from api import models
@@ -15,12 +15,16 @@ from api.models import User
 class InternalUserSerializer(ModelSerializer):
     """Serialize User for the internal API."""
 
+    # Include the account_number in the "username" field for backward compatability.
+    username = CharField(source="account_number", read_only=True)
+
     class Meta:
         model = User
         fields = (
             "date_joined",
             "id",
             "uuid",
+            "username",
             "account_number",
             "org_id",
         )

--- a/cloudigrade/internal/tests/viewsets/test_internaluserviewset.py
+++ b/cloudigrade/internal/tests/viewsets/test_internaluserviewset.py
@@ -1,0 +1,103 @@
+"""Collection of tests for InternalUserViewSet."""
+import faker
+from django.test import TestCase
+
+from api.tests import helper as api_helper
+from util.tests import helper as util_helper
+
+_faker = faker.Faker()
+
+
+class InternalUserViewSetTest(TestCase):
+    """InternalDailyConcurrentUsageViewSet test case."""
+
+    def setUp(self):
+        """Set up some test data."""
+        self.user1 = util_helper.generate_test_user(org_id=str(_faker.uuid4()))
+        self.user2 = util_helper.generate_test_user(org_id=str(_faker.uuid4()))
+        self.client = api_helper.SandboxedRestClient(
+            api_root="/internal/api/cloudigrade/v1"
+        )
+        self.client._force_authenticate(self.user1)
+
+    def assertJsonDictMatchesUsersList(self, response_dict, users):
+        """Assert that the response dict contains data for exactly the given users."""
+        data_list = response_dict["data"]
+        self.assertEqual(len(users), len(data_list))
+        for index, user in enumerate(users):
+            data_item = data_list[index]
+            self.assertEqual(user.account_number, data_item["account_number"])
+            self.assertEqual(user.org_id, data_item["org_id"])
+            self.assertEqual(user.uuid, data_item["uuid"])
+            self.assertEqual(user.account_number, data_item["username"])
+
+    def test_list_all_users(self):
+        """Assert all users are returned for unfiltered request."""
+        response = self.client.get_users()
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [self.user1, self.user2])
+
+    def test_list_users_filter_username(self):
+        """Assert using the username filter returns only the matching user."""
+        filter_args = {"username": str(self.user1.account_number)}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [self.user1])
+
+    def test_list_users_filter_username_not_found(self):
+        """Assert username filter with junk data excludes all users."""
+        filter_args = {"username": _faker.slug()}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [])
+
+    def test_list_users_filter_account_number(self):
+        """Assert using the account_number filter returns only the matching user."""
+        filter_args = {"account_number": str(self.user1.account_number)}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [self.user1])
+
+    def test_list_users_filter_account_number_not_found(self):
+        """Assert account_number filter with junk data excludes all users."""
+        filter_args = {"account_number": _faker.slug()}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [])
+
+    def test_list_users_filter_org_id(self):
+        """Assert using the org_id filter returns only the matching user."""
+        filter_args = {"org_id": str(self.user1.org_id)}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [self.user1])
+
+    def test_list_users_filter_org_id_not_found(self):
+        """Assert org_id filter with junk data excludes all users."""
+        filter_args = {"org_id": _faker.slug()}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [])
+
+    def test_list_users_filter_uuid(self):
+        """Assert using the uuid filter returns only the matching user."""
+        filter_args = {"uuid": str(self.user1.uuid)}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [self.user1])
+
+    def test_list_users_filter_uuid_not_found(self):
+        """Assert uuid filter with junk data excludes all users."""
+        filter_args = {"uuid": _faker.slug()}
+        response = self.client.get_users(data=filter_args)
+        self.assertEqual(response.status_code, 200)
+        response_dict = response.json()
+        self.assertJsonDictMatchesUsersList(response_dict, [])

--- a/cloudigrade/internal/viewsets.py
+++ b/cloudigrade/internal/viewsets.py
@@ -98,11 +98,7 @@ class InternalUserViewSet(InternalViewSetMixin, viewsets.ReadOnlyModelViewSet):
 
     queryset = User.objects.all()
     serializer_class = serializers.InternalUserSerializer
-    filterset_fields = {
-        "account_number": ["exact"],
-        "org_id": ["exact"],
-        "date_joined": ["lt", "exact", "gt"],
-    }
+    filterset_class = filters.InternalUserFilterSet
 
 
 class InternalUserTaskLockViewSet(

--- a/openapi-internal.json
+++ b/openapi-internal.json
@@ -449,15 +449,6 @@
             }
           },
           {
-            "name": "org_id",
-            "required": false,
-            "in": "query",
-            "description": "org_id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "date_joined__lt",
             "required": false,
             "in": "query",
@@ -480,6 +471,33 @@
             "required": false,
             "in": "query",
             "description": "date_joined__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "uuid",
+            "required": false,
+            "in": "query",
+            "description": "uuid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "username",
+            "required": false,
+            "in": "query",
+            "description": "username",
             "schema": {
               "type": "string"
             }
@@ -572,15 +590,6 @@
             }
           },
           {
-            "name": "org_id",
-            "required": false,
-            "in": "query",
-            "description": "org_id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "date_joined__lt",
             "required": false,
             "in": "query",
@@ -603,6 +612,33 @@
             "required": false,
             "in": "query",
             "description": "date_joined__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "uuid",
+            "required": false,
+            "in": "query",
+            "description": "uuid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "username",
+            "required": false,
+            "in": "query",
+            "description": "username",
             "schema": {
               "type": "string"
             }
@@ -7223,6 +7259,10 @@
           "uuid": {
             "type": "string",
             "maxLength": 150
+          },
+          "username": {
+            "type": "string",
+            "readOnly": true
           },
           "account_number": {
             "type": "string",


### PR DESCRIPTION
We removed the ability to filter the internal "users" API by the "username" query string argument in https://github.com/cloudigrade/cloudigrade/pull/1192, but we recently learned that the swatch service was relying on that. This change reimplements that filter by filtering on User.account_number with the given "username" and adds several unit tests to ensure we don't accidentally lose this in the future.

* allow filtering internal users API by "username" (which actually filters "account_number")
* add "username" to internal users API responses
* allow filtering internal users API by "uuid"