### PR TITLE
fix internal API filters that used "username" to use "account_number"

### DIFF
--- a/cloudigrade/api/tests/test_helper.py
+++ b/cloudigrade/api/tests/test_helper.py
@@ -44,11 +44,16 @@ class SandboxedRestClientTest(TestCase):
             org_id=self.org_id,
             password=self.password,
         )
+        self.x_rh_identity = util_helper.get_identity_auth_header(
+            self.account_number
+        ).decode("utf-8")
 
     def test_list_noun(self):
         """Assert "list" requests work."""
         client = helper.SandboxedRestClient()
-        client._force_authenticate(self.user)
+        client._force_authenticate(
+            self.user, {"HTTP_X_RH_IDENTITY": self.x_rh_identity}
+        )
         response = client.list_accounts()
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
         response_json = response.json()
@@ -66,7 +71,9 @@ class SandboxedRestClientTest(TestCase):
     def test_create_noun(self, mock_notify_sources):
         """Assert "create" requests work."""
         client = helper.SandboxedRestClient(api_root="/internal/api/cloudigrade/v1")
-        client._force_authenticate(self.user)
+        client._force_authenticate(
+            self.user, {"HTTP_X_RH_IDENTITY": self.x_rh_identity}
+        )
         arn = util_helper.generate_dummy_arn()
         data = util_helper.generate_dummy_aws_cloud_account_post_data()
         data.update({"account_arn": arn})
@@ -79,7 +86,9 @@ class SandboxedRestClientTest(TestCase):
     def test_get_noun(self):
         """Assert "get" requests work."""
         client = helper.SandboxedRestClient()
-        client._force_authenticate(self.user)
+        client._force_authenticate(
+            self.user, {"HTTP_X_RH_IDENTITY": self.x_rh_identity}
+        )
         account = helper.generate_cloud_account(user=self.user)
         response = client.get_accounts(account.id)
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
@@ -95,7 +104,9 @@ class SandboxedRestClientTest(TestCase):
     def test_action_noun_verb_detail(self):
         """Assert "detail" requests work."""
         client = helper.SandboxedRestClient()
-        client._force_authenticate(self.user)
+        client._force_authenticate(
+            self.user, {"HTTP_X_RH_IDENTITY": self.x_rh_identity}
+        )
 
         account = helper.generate_cloud_account(user=self.user)
         image = helper.generate_image(status=MachineImage.INSPECTED)

--- a/cloudigrade/internal/filters.py
+++ b/cloudigrade/internal/filters.py
@@ -10,7 +10,9 @@ from api.filters import InstanceRunningSinceFilter
 class InternalCloudAccountFilterSet(django_filters.FilterSet):
     """FilterSet for limiting CloudAccounts for the internal API."""
 
-    username = django_filters.CharFilter(field_name="user__username")
+    account_number = django_filters.CharFilter(field_name="user__account_number")
+    org_id = django_filters.CharFilter(field_name="user__org_id")
+    username = django_filters.CharFilter(field_name="user__account_number")
 
     class Meta:
         model = models.CloudAccount
@@ -31,8 +33,14 @@ class InternalCloudAccountFilterSet(django_filters.FilterSet):
 class InternalInstanceFilterSet(django_filters.FilterSet):
     """FilterSet for limiting Instances for the internal API."""
 
+    account_number = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
+    org_id = django_filters.CharFilter(field_name="cloud_account__user__org_id")
     running_since = InstanceRunningSinceFilter()
-    username = django_filters.CharFilter(field_name="cloud_account__user__username")
+    username = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
 
     class Meta:
         model = models.Instance
@@ -48,8 +56,14 @@ class InternalInstanceFilterSet(django_filters.FilterSet):
 class InternalInstanceEventFilterSet(django_filters.FilterSet):
     """FilterSet for limiting InstanceEvents for the internal API."""
 
+    account_number = django_filters.CharFilter(
+        field_name="instance__cloud_account__user__account_number"
+    )
+    org_id = django_filters.CharFilter(
+        field_name="instance__cloud_account__user__org_id"
+    )
     username = django_filters.CharFilter(
-        field_name="instance__cloud_account__user__username"
+        field_name="instance__cloud_account__user__account_number"
     )
     cloud_account = django_filters.NumberFilter(field_name="instance__cloud_account")
 
@@ -82,8 +96,14 @@ class InternalUserFilterSet(django_filters.FilterSet):
 class InternalRunFilterSet(django_filters.FilterSet):
     """FilterSet for limiting Runs for the internal API."""
 
+    account_number = django_filters.CharFilter(
+        field_name="instance__cloud_account__user__account_number"
+    )
+    org_id = django_filters.CharFilter(
+        field_name="instance__cloud_account__user__org_id"
+    )
     username = django_filters.CharFilter(
-        field_name="instance__cloud_account__user__username"
+        field_name="instance__cloud_account__user__account_number"
     )
     cloud_account = django_filters.NumberFilter(field_name="instance__cloud_account")
 
@@ -105,7 +125,9 @@ class InternalRunFilterSet(django_filters.FilterSet):
 class InternalConcurrentUsageFilterSet(django_filters.FilterSet):
     """FilterSet for limiting ConcurrentUsages for the internal API."""
 
-    username = django_filters.CharFilter(field_name="user__username")
+    account_number = django_filters.CharFilter(field_name="user__account_number")
+    org_id = django_filters.CharFilter(field_name="user__org_id")
+    username = django_filters.CharFilter(field_name="user__account_number")
     run = django_filters.NumberFilter(field_name="potentially_related_runs")
 
     class Meta:
@@ -120,7 +142,13 @@ class InternalConcurrentUsageFilterSet(django_filters.FilterSet):
 class InternalAwsCloudAccountFilterSet(django_filters.FilterSet):
     """FilterSet for limiting AwsCloudAccounts for the internal API."""
 
-    username = django_filters.CharFilter(field_name="cloud_account__user__username")
+    account_number = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
+    org_id = django_filters.CharFilter(field_name="cloud_account__user__org_id")
+    username = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
 
     class Meta:
         model = aws_models.AwsCloudAccount
@@ -135,7 +163,13 @@ class InternalAwsCloudAccountFilterSet(django_filters.FilterSet):
 class InternalAzureCloudAccountFilterSet(django_filters.FilterSet):
     """FilterSet for limiting AzureCloudAccounts for the internal API."""
 
-    username = django_filters.CharFilter(field_name="cloud_account__user__username")
+    account_number = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
+    org_id = django_filters.CharFilter(field_name="cloud_account__user__org_id")
+    username = django_filters.CharFilter(
+        field_name="cloud_account__user__account_number"
+    )
 
     class Meta:
         model = azure_models.AzureCloudAccount

--- a/cloudigrade/util/filters.py
+++ b/cloudigrade/util/filters.py
@@ -43,7 +43,7 @@ def stringify_http_response(response):
     return fulltext
 
 
-def httpied_command(wsgi_request, version=1, public=False):
+def httpied_command(wsgi_request, anonymous=False):
     """Construct an `httpie` command line string for the given request."""
     verb = wsgi_request.method.lower()
     url = wsgi_request.build_absolute_uri()
@@ -53,15 +53,11 @@ def httpied_command(wsgi_request, version=1, public=False):
     else:
         cli_text = " ".join(["http", verb, url])
 
-    if not public:
-        if version == 2:
-            cli_text += ' "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"'
-        else:
-            if getattr(wsgi_request, "user", None):
-                print(getattr(wsgi_request, "user", None))
-                cli_text += ' "${AUTH}"'
-
     linewrap = " \\\n    "
+
+    if not anonymous:
+        cli_text += f'{linewrap}"X-RH-IDENTITY:${{HTTP_X_RH_IDENTITY}}"'
+
     for key, value in wsgi_request.GET.items():
         cli_text += f'{linewrap}{key}=="{value}"'
     for key, value in wsgi_request.POST.items():

--- a/cloudigrade/util/tests/test_filters.py
+++ b/cloudigrade/util/tests/test_filters.py
@@ -94,8 +94,8 @@ class Jinja2FiltersTest(TestCase):
         actual = filters.stringify_http_response(response)
         self.assertEqual(expected, actual)
 
-    def test_httpied_command_v2_includes_x_hr_identity(self):
-        """Assert httpied_command with version=2 includes X_RH_IDENTITY."""
+    def test_httpied_command_includes_x_hr_identity(self):
+        """Assert httpied_command includes X_RH_IDENTITY."""
         uri = "http://localhost/api/cloudigrade/v2/ok"
 
         mock_request = MagicMock()
@@ -103,15 +103,16 @@ class Jinja2FiltersTest(TestCase):
         mock_request.user = None
         mock_request.build_absolute_uri.return_value = uri
 
-        expected = (
-            "http http://localhost/api/cloudigrade/v2/ok "
-            '"X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"'
-        )
-        actual = filters.httpied_command(mock_request, version=2)
+        expected = """
+            http http://localhost/api/cloudigrade/v2/ok \\
+                "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+            """  # noqa: E501
+        expected = textwrap.dedent(expected)[1:-1]  # trim whitespace
+        actual = filters.httpied_command(mock_request)
         self.assertEqual(expected, actual)
 
-    def test_httpied_command_v2_allow_public(self):
-        """Assert httpied_command with public=True includes no auth headers."""
+    def test_httpied_command_allow_anonymous(self):
+        """Assert httpied_command with anonymous=True includes no auth headers."""
         uri = "http://localhost/api/cloudigrade/v2/ok"
 
         mock_request = MagicMock()
@@ -120,5 +121,5 @@ class Jinja2FiltersTest(TestCase):
         mock_request.build_absolute_uri.return_value = uri
 
         expected = "http http://localhost/api/cloudigrade/v2/ok"
-        actual = filters.httpied_command(mock_request, public=True)
+        actual = filters.httpied_command(mock_request, anonymous=True)
         self.assertEqual(expected, actual)

--- a/docs/rest-api-examples.py
+++ b/docs/rest-api-examples.py
@@ -440,15 +440,15 @@ if __name__ == "__main__":
     ):
         mock_uuid4.side_effect = seeded_uuid4
         mock_azure_enable.return_value = True
-        api_hander = DocsApiHandler()
-        authenticated_responses = api_hander.gather_api_responses()
-        internal_responses = api_hander.gather_internal_api_responses()
-        anonymous_responses = api_hander.gather_anonymous_api_responses()
+        api_handler = DocsApiHandler()
+        authenticated_responses = api_handler.gather_api_responses()
+        internal_responses = api_handler.gather_internal_api_responses()
+        anonymous_responses = api_handler.gather_anonymous_api_responses()
         transaction.set_rollback(True)
-    responses = {}
-    responses.update(authenticated_responses)
-    responses.update(internal_responses)
-    responses.update(anonymous_responses)
-    output = render(responses)
+    all_responses = {}
+    all_responses.update(authenticated_responses)
+    all_responses.update(internal_responses)
+    all_responses.update(anonymous_responses)
+    output = render(all_responses)
     output = "\n".join((line.rstrip() for line in output.split("\n")))
     print(output)

--- a/docs/rest-api-examples.py
+++ b/docs/rest-api-examples.py
@@ -331,6 +331,15 @@ class DocsApiHandler(object):
         """
         responses = dict()
 
+        _faker = faker.Faker()
+
+        psk = str(_faker.uuid4())
+        account_number = str(_faker.random_int(min=10000, max=999999))
+        org_id = str(_faker.random_int(min=10000, max=999999))
+        responses["internal_psk"] = psk
+        responses["internal_account_number"] = account_number
+        responses["internal_org_id"] = org_id
+
         ############################
         # Internal Customer Account Setup AWS
 

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -46,6 +46,22 @@ The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data l
 
     HTTP_X_RH_IDENTITY=eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTMzNyIsICJ1c2VyIjogeyJpc19vcmdfYWRtaW4iOiB0cnVlfX19
 
+Some internal APIs may instead accept a combination of these custom HTTP headers:
+
+* ``X-RH-CLOUDIGRADE-PSK`` contains a pre-shared key (secret)
+* ``X-RH-CLOUDIGRADE-ACCOUNT-NUMBER`` contains the EBS account number for the user
+* ``X-RH-CLOUDIGRADE-ORG-ID`` contains the consoledot org ID for the user
+
+These three headers are not populated automatically by 3scale and must be explicitly
+defined by the caller as needed. This document will populate them using the following
+environment variables:
+
+.. code:: bash
+
+    HTTP_X_RH_CLOUDIGRADE_PSK=c17c6279-23c6-412f-8826-867323a7711a
+    HTTP_X_RH_CLOUDIGRADE_ACCOUNT_NUMBER=109437
+    HTTP_X_RH_CLOUDIGRADE_ORG_ID=658406
+
 Overview
 --------
 
@@ -2366,9 +2382,9 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
         account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
-        platform_authentication_id="2281" \
-        platform_application_id="4617" \
-        platform_source_id="2289"
+        platform_authentication_id="4104" \
+        platform_application_id="8725" \
+        platform_source_id="9861"
 
 Response:
 
@@ -2395,10 +2411,10 @@ Response:
         },
         "created_at": "2020-05-18T13:51:59.722367Z",
         "is_enabled": true,
-        "platform_application_id": 4617,
+        "platform_application_id": 8725,
         "platform_application_is_paused": false,
-        "platform_authentication_id": 2281,
-        "platform_source_id": 2289,
+        "platform_authentication_id": 4104,
+        "platform_source_id": 9861,
         "updated_at": "2020-05-18T13:51:59.722367Z",
         "user_id": 1
     }
@@ -2413,9 +2429,9 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
         account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
-        platform_authentication_id="1553" \
-        platform_application_id="4104" \
-        platform_source_id="8725"
+        platform_authentication_id="2407" \
+        platform_application_id="5081" \
+        platform_source_id="1618"
 
 Response:
 
@@ -2448,9 +2464,9 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="azure" \
         subscription_id="9192e037-3a17-46d1-a2e3-a0c780b2866b" \
-        platform_authentication_id="9861" \
-        platform_application_id="2407" \
-        platform_source_id="5081"
+        platform_authentication_id="1208" \
+        platform_application_id="5409" \
+        platform_source_id="7735"
 
 Response:
 
@@ -2476,10 +2492,10 @@ Response:
         },
         "created_at": "2020-05-18T13:51:59.722367Z",
         "is_enabled": true,
-        "platform_application_id": 2407,
+        "platform_application_id": 5409,
         "platform_application_is_paused": false,
-        "platform_authentication_id": 9861,
-        "platform_source_id": 5081,
+        "platform_authentication_id": 1208,
+        "platform_source_id": 7735,
         "updated_at": "2020-05-18T13:51:59.722367Z",
         "user_id": 1
     }

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -94,7 +94,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/accounts/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -168,7 +169,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/accounts/1/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/accounts/1/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -214,7 +216,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/instances/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/instances/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -341,7 +344,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/instances/1/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/instances/1/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -383,7 +387,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/instances/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/instances/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         running_since=="2020-05-18 13:51:59.722367+00:00"
 
 Response:
@@ -501,7 +506,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/images/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/images/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -766,7 +772,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/images/1/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/images/1/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -846,7 +853,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/concurrent/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/concurrent/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         start_date=="2020-05-11"
 
 Response:
@@ -2069,7 +2077,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/concurrent/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/concurrent/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         start_date=="2020-04-17"
 
 Response:
@@ -2097,7 +2106,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/concurrent/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/concurrent/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         start_date=="2020-05-17" \
         end_date=="2020-05-25"
 
@@ -2128,7 +2138,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/concurrent/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/concurrent/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         start_date=="2020-05-19" \
         end_date=="2020-05-25"
 
@@ -2161,7 +2172,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/concurrent/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http localhost:8080/api/cloudigrade/v2/concurrent/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         start_date=="2018-12-18 00:00:00+00:00" \
         end_date=="2018-12-25 00:00:00+00:00"
 
@@ -2199,7 +2211,8 @@ Request:
 
 .. code:: bash
 
-    http localhost:8080/api/cloudigrade/v2/sysconfig/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
+    http localhost:8080/api/cloudigrade/v2/sysconfig/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}"
 
 Response:
 
@@ -2379,7 +2392,8 @@ Request:
 
 .. code:: bash
 
-    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
         account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
         platform_authentication_id="4104" \
@@ -2426,7 +2440,8 @@ Request:
 
 .. code:: bash
 
-    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
         account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
         platform_authentication_id="2407" \
@@ -2461,7 +2476,8 @@ Request:
 
 .. code:: bash
 
-    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
+    http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
+        "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="azure" \
         subscription_id="9192e037-3a17-46d1-a2e3-a0c780b2866b" \
         platform_authentication_id="1208" \

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -20,12 +20,15 @@ These examples also assume you are running cloudigrade on
 cloudigrade’s environment with appropriate variables to allow it to talk
 to the various clouds (e.g. ``AWS_ACCESS_KEY_ID``).
 
-Authorization
--------------
+Authentication
+--------------
 
-The v2 API is authenticated with a custom HTTP header. In order to authenticate,
-a `HTTP_X_RH_IDENTITY` header must be included in the request.
-This header must be the base64 encoded version of:
+Most requests to cloudigrade's APIs require a custom HTTP header ``X-RH-IDENTITY`` that
+describes the caller's identity. For Red Hat "consoledot" services, this header is
+normally populated automatically by a 3scale gateway, but this document will populate
+it by using an ``HTTP_X_RH_IDENTITY`` environment variable.
+
+The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data like:
 
 
 .. code:: json

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -35,7 +35,7 @@ The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data l
 
     {
         "identity": {
-            "account_number": "1337",
+            "account_number": "100001",
             "user": {
                 "is_org_admin": true
             }
@@ -44,7 +44,7 @@ The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data l
 
 .. code:: bash
 
-    HTTP_X_RH_IDENTITY=eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTMzNyIsICJ1c2VyIjogeyJpc19vcmdfYWRtaW4iOiB0cnVlfX19
+    HTTP_X_RH_IDENTITY=eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDAxIiwgInVzZXIiOiB7ImlzX29yZ19hZG1pbiI6IHRydWV9fX0=
 
 Some internal APIs may instead accept a combination of these custom HTTP headers:
 
@@ -106,7 +106,7 @@ Response:
     Content-Length: 1138
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 84c299fd-13bf-4de7-8134-4a89e6996ad3
+    X-CLOUDIGRADE-REQUEST-ID: fd13bf6d-e7c1-444a-89e6-996ad3f87bd8
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -116,8 +116,8 @@ Response:
                 "account_id": 1,
                 "cloud_type": "aws",
                 "content_object": {
-                    "account_arn": "arn:aws:iam::161534339699:role/role-for-cloudigrade",
-                    "aws_account_id": "161534339699",
+                    "account_arn": "arn:aws:iam::116325369465:role/role-for-cloudigrade",
+                    "aws_account_id": "116325369465",
                     "aws_cloud_account_id": 1,
                     "created_at": "2020-05-04T00:00:00Z",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
@@ -137,7 +137,7 @@ Response:
                 "content_object": {
                     "azure_cloud_account_id": 1,
                     "created_at": "2020-05-04T00:00:00Z",
-                    "subscription_id": "c1189ecc-40fc-4888-bbb4-cf9ae6254f19",
+                    "subscription_id": "9ecc40fc-e888-4bb4-8f9a-e6254f19ba12",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-04T00:00:00Z",
@@ -181,7 +181,7 @@ Response:
     Content-Length: 496
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: f87bd8ca-f863-4b96-bbd9-ddcc05a8e200
+    X-CLOUDIGRADE-REQUEST-ID: caf8639b-963b-49dd-8c05-a8e200bd2e4d
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -189,8 +189,8 @@ Response:
         "account_id": 1,
         "cloud_type": "aws",
         "content_object": {
-            "account_arn": "arn:aws:iam::161534339699:role/role-for-cloudigrade",
-            "aws_account_id": "161534339699",
+            "account_arn": "arn:aws:iam::116325369465:role/role-for-cloudigrade",
+            "aws_account_id": "116325369465",
             "aws_cloud_account_id": 1,
             "created_at": "2020-05-04T00:00:00Z",
             "updated_at": "2020-05-18T13:51:59.722367Z"
@@ -225,10 +225,10 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 2617
+    Content-Length: 2611
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: bd2e4d81-9141-4510-bedc-43f1d34dc568
+    X-CLOUDIGRADE-REQUEST-ID: 81914155-107e-4c43-b1d3-4dc56862cf62
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -240,8 +240,8 @@ Response:
                 "content_object": {
                     "aws_instance_id": 1,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_instance_id": "i-af3bda6fe8102c0fa",
-                    "region": "ap-northeast-1",
+                    "ec2_instance_id": "i-f3bda6fe8102c0fa7",
+                    "region": "eu-west-1",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -255,7 +255,7 @@ Response:
                 "content_object": {
                     "aws_instance_id": 2,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_instance_id": "i-2af3993a69e2ca795",
+                    "ec2_instance_id": "i-af3993a69e2ca7956",
                     "region": "ap-northeast-1",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
@@ -270,8 +270,8 @@ Response:
                 "content_object": {
                     "aws_instance_id": 3,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_instance_id": "i-12c876d8efb2a3fa6",
-                    "region": "ca-central-1",
+                    "ec2_instance_id": "i-2c876d8efb2a3fa67",
+                    "region": "ap-northeast-1",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -285,8 +285,8 @@ Response:
                 "content_object": {
                     "azure_instance_id": 1,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "region": "North Europe",
-                    "resource_id": "/subscriptions/d00f19c8-25da-4238-8bd1-92a2e8ef889a/resourceGroups/interview/providers/Microsoft.Compute/virtualMachines/why",
+                    "region": "East US",
+                    "resource_id": "/subscriptions/19c825da-b238-4bd1-92a2-e8ef889aae12/resourceGroups/interview/providers/Microsoft.Compute/virtualMachines/why",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -301,7 +301,7 @@ Response:
                     "azure_instance_id": 2,
                     "created_at": "2020-05-18T13:51:59.722367Z",
                     "region": "East US",
-                    "resource_id": "/subscriptions/9b0531f6-f82f-471f-ba35-bacc0fefad05/resourceGroups/floor/providers/Microsoft.Compute/virtualMachines/me",
+                    "resource_id": "/subscriptions/31f6f82f-b71f-4a35-bacc-0fefad058b6c/resourceGroups/floor/providers/Microsoft.Compute/virtualMachines/me",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -315,8 +315,8 @@ Response:
                 "content_object": {
                     "azure_instance_id": 3,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "region": "North Europe",
-                    "resource_id": "/subscriptions/0a9819b3-fc64-4342-9be7-bb78d6e6eb91/resourceGroups/wait/providers/Microsoft.Compute/virtualMachines/whatever",
+                    "region": "EAST US 2 EUAP",
+                    "resource_id": "/subscriptions/19b3fc64-3342-4be7-bb78-d6e6eb912bb2/resourceGroups/wait/providers/Microsoft.Compute/virtualMachines/whatever",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -353,10 +353,10 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 355
+    Content-Length: 350
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 62cf620f-29a4-4f20-bd49-bad4550ef109
+    X-CLOUDIGRADE-REQUEST-ID: 0f29a4ef-203d-49ba-9455-0ef1097b6a24
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -366,8 +366,8 @@ Response:
         "content_object": {
             "aws_instance_id": 1,
             "created_at": "2020-05-18T13:51:59.722367Z",
-            "ec2_instance_id": "i-af3bda6fe8102c0fa",
-            "region": "ap-northeast-1",
+            "ec2_instance_id": "i-f3bda6fe8102c0fa7",
+            "region": "eu-west-1",
             "updated_at": "2020-05-18T13:51:59.722367Z"
         },
         "created_at": "2020-05-18T13:51:59.722367Z",
@@ -397,10 +397,10 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 2373
+    Content-Length: 2365
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 7b6a247d-e3dd-4ab7-94ac-b226cffc5a69
+    X-CLOUDIGRADE-REQUEST-ID: 7de3dd9a-b714-4cb2-a6cf-fc5a69099c77
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -412,8 +412,8 @@ Response:
                 "content_object": {
                     "aws_instance_id": 1,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_instance_id": "i-af3bda6fe8102c0fa",
-                    "region": "ap-northeast-1",
+                    "ec2_instance_id": "i-f3bda6fe8102c0fa7",
+                    "region": "eu-west-1",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -427,7 +427,7 @@ Response:
                 "content_object": {
                     "aws_instance_id": 2,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_instance_id": "i-2af3993a69e2ca795",
+                    "ec2_instance_id": "i-af3993a69e2ca7956",
                     "region": "ap-northeast-1",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
@@ -442,8 +442,8 @@ Response:
                 "content_object": {
                     "azure_instance_id": 1,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "region": "North Europe",
-                    "resource_id": "/subscriptions/d00f19c8-25da-4238-8bd1-92a2e8ef889a/resourceGroups/interview/providers/Microsoft.Compute/virtualMachines/why",
+                    "region": "East US",
+                    "resource_id": "/subscriptions/19c825da-b238-4bd1-92a2-e8ef889aae12/resourceGroups/interview/providers/Microsoft.Compute/virtualMachines/why",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -458,7 +458,7 @@ Response:
                     "azure_instance_id": 2,
                     "created_at": "2020-05-18T13:51:59.722367Z",
                     "region": "East US",
-                    "resource_id": "/subscriptions/9b0531f6-f82f-471f-ba35-bacc0fefad05/resourceGroups/floor/providers/Microsoft.Compute/virtualMachines/me",
+                    "resource_id": "/subscriptions/31f6f82f-b71f-4a35-bacc-0fefad058b6c/resourceGroups/floor/providers/Microsoft.Compute/virtualMachines/me",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -472,8 +472,8 @@ Response:
                 "content_object": {
                     "azure_instance_id": 3,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "region": "North Europe",
-                    "resource_id": "/subscriptions/0a9819b3-fc64-4342-9be7-bb78d6e6eb91/resourceGroups/wait/providers/Microsoft.Compute/virtualMachines/whatever",
+                    "region": "EAST US 2 EUAP",
+                    "resource_id": "/subscriptions/19b3fc64-3342-4be7-bb78-d6e6eb912bb2/resourceGroups/wait/providers/Microsoft.Compute/virtualMachines/whatever",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -518,7 +518,7 @@ Response:
     Content-Length: 6922
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 099c7762-750c-4978-8726-0508999e21a1
+    X-CLOUDIGRADE-REQUEST-ID: 62750c19-78c7-4605-8899-9e21a1521ab3
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -530,11 +530,11 @@ Response:
                 "content_object": {
                     "aws_image_id": 1,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_ami_id": "ami-7a26774e",
+                    "ec2_ami_id": "ami-a26774e2",
                     "id": 1,
                     "is_cloud_access": false,
                     "is_marketplace": false,
-                    "owner_aws_account_id": "161534339699",
+                    "owner_aws_account_id": "116325369465",
                     "platform": "none",
                     "platform_details": null,
                     "product_codes": null,
@@ -571,11 +571,11 @@ Response:
                 "content_object": {
                     "aws_image_id": 2,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_ami_id": "ami-6518f224",
+                    "ec2_ami_id": "ami-518f2244",
                     "id": 2,
                     "is_cloud_access": false,
                     "is_marketplace": false,
-                    "owner_aws_account_id": "161534339699",
+                    "owner_aws_account_id": "116325369465",
                     "platform": "none",
                     "platform_details": null,
                     "product_codes": null,
@@ -612,11 +612,11 @@ Response:
                 "content_object": {
                     "aws_image_id": 3,
                     "created_at": "2020-05-18T13:51:59.722367Z",
-                    "ec2_ami_id": "ami-70837b5a",
+                    "ec2_ami_id": "ami-0837b5ad",
                     "id": 3,
                     "is_cloud_access": false,
                     "is_marketplace": false,
-                    "owner_aws_account_id": "161534339699",
+                    "owner_aws_account_id": "116325369465",
                     "platform": "none",
                     "platform_details": null,
                     "product_codes": null,
@@ -656,7 +656,7 @@ Response:
                     "id": 1,
                     "is_marketplace": false,
                     "region": null,
-                    "resource_id": "/subscriptions/ae12061f-a230-4bd4-931e-64175ed5fb1d/resourceGroups/step/providers/Microsoft.Compute/images/themselves",
+                    "resource_id": "/subscriptions/061fa230-9bd4-431e-a417-5ed5fb1d099b/resourceGroups/step/providers/Microsoft.Compute/images/themselves",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -691,7 +691,7 @@ Response:
                     "id": 2,
                     "is_marketplace": false,
                     "region": null,
-                    "resource_id": "/subscriptions/8b6c9e19-d542-4138-92a5-4d596f2e0f80/resourceGroups/help/providers/Microsoft.Compute/images/past",
+                    "resource_id": "/subscriptions/9e19d542-1138-42a5-8d59-6f2e0f80770a/resourceGroups/help/providers/Microsoft.Compute/images/past",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -726,7 +726,7 @@ Response:
                     "id": 3,
                     "is_marketplace": false,
                     "region": null,
-                    "resource_id": "/subscriptions/2bb2ac34-f7c4-4ec9-ad28-d8295787401e/resourceGroups/discover/providers/Microsoft.Compute/images/mother",
+                    "resource_id": "/subscriptions/ac34f7c4-0ec9-4d28-9829-5787401e98eb/resourceGroups/discover/providers/Microsoft.Compute/images/mother",
                     "updated_at": "2020-05-18T13:51:59.722367Z"
                 },
                 "created_at": "2020-05-18T13:51:59.722367Z",
@@ -784,7 +784,7 @@ Response:
     Content-Length: 1143
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 521ab38c-a658-4162-88c6-c77d1ce10f9c
+    X-CLOUDIGRADE-REQUEST-ID: 8ca65831-62c8-46c7-bd1c-e10f9cb3779d
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -794,11 +794,11 @@ Response:
         "content_object": {
             "aws_image_id": 1,
             "created_at": "2020-05-18T13:51:59.722367Z",
-            "ec2_ami_id": "ami-7a26774e",
+            "ec2_ami_id": "ami-a26774e2",
             "id": 1,
             "is_cloud_access": false,
             "is_marketplace": false,
-            "owner_aws_account_id": "161534339699",
+            "owner_aws_account_id": "116325369465",
             "platform": "none",
             "platform_details": null,
             "product_codes": null,
@@ -866,7 +866,7 @@ Response:
     Content-Length: 17102
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 42b32872-87e2-4ce8-8f9a-c100e2097e53
+    X-CLOUDIGRADE-REQUEST-ID: 7287e27c-e88f-4ac1-80e2-097e534fd677
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2090,7 +2090,7 @@ Response:
     Content-Length: 64
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 9ac827d7-6195-4bb7-b4ce-7810cc1584de
+    X-CLOUDIGRADE-REQUEST-ID: d761954b-b7b4-4e78-90cc-1584deea0a10
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2120,7 +2120,7 @@ Response:
     Content-Length: 50
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: ee380257-b4f6-4fe6-91d1-52098625df41
+    X-CLOUDIGRADE-REQUEST-ID: 57b4f6bf-e651-4152-8986-25df419ac827
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2152,7 +2152,7 @@ Response:
     Content-Length: 112
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: ea0a1039-210a-4c03-82d8-7254dc29cc26
+    X-CLOUDIGRADE-REQUEST-ID: 39210a4c-03c2-4872-94dc-29cc26dea775
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2186,7 +2186,7 @@ Response:
     Content-Length: 151
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: dea775f7-5f81-41e6-8780-089217adcbce
+    X-CLOUDIGRADE-REQUEST-ID: f75f8161-e687-4008-9217-adcbce84c299
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2223,7 +2223,7 @@ Response:
     Content-Length: 680
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: b3779da1-ef56-461f-b8ae-b69f4bc9d920
+    X-CLOUDIGRADE-REQUEST-ID: a1ef56a6-1ff8-4eb6-9f4b-c9d920f5e963
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2282,7 +2282,7 @@ Response:
     Content-Length: 2017
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 53b84014-5a12-4f5b-b107-58592d02d4f9
+    X-CLOUDIGRADE-REQUEST-ID: f93bd15d-1298-4424-b500-34a8acbbf0e6
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2395,7 +2395,7 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
         "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
-        account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
+        account_arn="arn:aws:iam::335555691572:role/role-for-cloudigrade" \
         platform_authentication_id="4104" \
         platform_application_id="8725" \
         platform_source_id="9861"
@@ -2409,7 +2409,7 @@ Response:
     Content-Length: 511
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: f5aefbcf-1f84-4cc9-be30-09c864715fc1
+    X-CLOUDIGRADE-REQUEST-ID: dff5aefb-cf1f-44dc-89fe-3009c864715f
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2417,8 +2417,8 @@ Response:
         "account_id": 3,
         "cloud_type": "aws",
         "content_object": {
-            "account_arn": "arn:aws:iam::887838253945:role/role-for-cloudigrade",
-            "aws_account_id": "887838253945",
+            "account_arn": "arn:aws:iam::335555691572:role/role-for-cloudigrade",
+            "aws_account_id": "335555691572",
             "aws_cloud_account_id": 2,
             "created_at": "2020-05-18T13:51:59.722367Z",
             "updated_at": "2020-05-18T13:51:59.722367Z"
@@ -2443,7 +2443,7 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
         "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="aws" \
-        account_arn="arn:aws:iam::887838253945:role/role-for-cloudigrade" \
+        account_arn="arn:aws:iam::335555691572:role/role-for-cloudigrade" \
         platform_authentication_id="2407" \
         platform_application_id="5081" \
         platform_source_id="1618"
@@ -2457,7 +2457,7 @@ Response:
     Content-Length: 157
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 5bcaa113-f40b-46ef-8a7c-41e606f185aa
+    X-CLOUDIGRADE-REQUEST-ID: 745bcaa1-13f4-4be6-af0a-7c41e606f185
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2479,7 +2479,7 @@ Request:
     http post localhost:8080/internal/api/cloudigrade/v1/accounts/ \
         "X-RH-IDENTITY:${HTTP_X_RH_IDENTITY}" \
         cloud_type="azure" \
-        subscription_id="9192e037-3a17-46d1-a2e3-a0c780b2866b" \
+        subscription_id="aa9192e0-373a-47c6-91e2-e3a0c780b286" \
         platform_authentication_id="1208" \
         platform_application_id="5409" \
         platform_source_id="7735"
@@ -2493,7 +2493,7 @@ Response:
     Content-Length: 472
     Content-Type: application/json
     Referrer-Policy: same-origin
-    X-CLOUDIGRADE-REQUEST-ID: 6ac627bb-f407-4a72-aeaf-6a077febddf6
+    X-CLOUDIGRADE-REQUEST-ID: 196ac627-bbf4-47ca-b26e-af6a077febdd
     X-Content-Type-Options: nosniff
     X-Frame-Options: DENY
 
@@ -2503,7 +2503,7 @@ Response:
         "content_object": {
             "azure_cloud_account_id": 2,
             "created_at": "2020-05-18T13:51:59.722367Z",
-            "subscription_id": "9192e037-3a17-46d1-a2e3-a0c780b2866b",
+            "subscription_id": "aa9192e0-373a-47c6-91e2-e3a0c780b286",
             "updated_at": "2020-05-18T13:51:59.722367Z"
         },
         "created_at": "2020-05-18T13:51:59.722367Z",
@@ -2514,4 +2514,53 @@ Response:
         "platform_source_id": 7735,
         "updated_at": "2020-05-18T13:51:59.722367Z",
         "user_id": 1
+    }
+
+
+Search for a user
+~~~~~~~~~~~~~~~~~
+
+To search for and retrieve a user, you may filter using "account_number", "username"
+(which simply maps to the account_number for backward compatibility), or "org_id".
+
+Request:
+
+.. code:: bash
+
+    http localhost:8080/internal/api/cloudigrade/v1/users/ \
+        "X-RH-CLOUDIGRADE-PSK:${HTTP_X_RH_CLOUDIGRADE_PSK}" \
+        account_number=="100001"
+
+
+::
+
+    HTTP/1.1 200 OK
+    Allow: GET, HEAD, OPTIONS
+    Content-Length: 390
+    Content-Type: application/json
+    Referrer-Policy: same-origin
+    X-CLOUDIGRADE-REQUEST-ID: f653b840-145a-421f-9bb1-0758592d02d4
+    X-Content-Type-Options: nosniff
+    X-Frame-Options: DENY
+
+    {
+        "data": [
+            {
+                "account_number": "100001",
+                "date_joined": "2019-01-01T00:00:00Z",
+                "id": 1,
+                "org_id": null,
+                "username": "100001",
+                "uuid": "d862c2e3-6b0a-42f7-827c-67ebc8d44df7"
+            }
+        ],
+        "links": {
+            "first": "/internal/api/cloudigrade/v1/users/?account_number=100001&limit=10&offset=0",
+            "last": "/internal/api/cloudigrade/v1/users/?account_number=100001&limit=10&offset=0",
+            "next": null,
+            "previous": null
+        },
+        "meta": {
+            "count": 1
+        }
     }

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -59,8 +59,10 @@ The following resource paths are currently available:
 User Setup
 ------------------
 
-When accessing any endpoint with the HTTP_X_RH_IDENTITY header,
-if the user found in the header does not exist, it will not be created.
+Users are not typically created via interaction with the HTTP APIs.
+When accessing any endpoint with the ``X-RH-IDENTITY`` header,
+if the user found in the header does not exist, it will not be created,
+but not all APIs require that a corresponding cloudigrade user exists.
 
 
 Customer Account Info

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -37,6 +37,22 @@ The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data l
 
     HTTP_X_RH_IDENTITY={{v2_header}}
 
+Some internal APIs may instead accept a combination of these custom HTTP headers:
+
+* ``X-RH-CLOUDIGRADE-PSK`` contains a pre-shared key (secret)
+* ``X-RH-CLOUDIGRADE-ACCOUNT-NUMBER`` contains the EBS account number for the user
+* ``X-RH-CLOUDIGRADE-ORG-ID`` contains the consoledot org ID for the user
+
+These three headers are not populated automatically by 3scale and must be explicitly
+defined by the caller as needed. This document will populate them using the following
+environment variables:
+
+.. code:: bash
+
+    HTTP_X_RH_CLOUDIGRADE_PSK={{internal_psk}}
+    HTTP_X_RH_CLOUDIGRADE_ACCOUNT_NUMBER={{internal_account_number}}
+    HTTP_X_RH_CLOUDIGRADE_ORG_ID={{internal_org_id}}
+
 Overview
 --------
 

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -20,12 +20,15 @@ These examples also assume you are running cloudigrade on
 cloudigrade’s environment with appropriate variables to allow it to talk
 to the various clouds (e.g. ``AWS_ACCESS_KEY_ID``).
 
-Authorization
--------------
+Authentication
+--------------
 
-The v2 API is authenticated with a custom HTTP header. In order to authenticate,
-a `HTTP_X_RH_IDENTITY` header must be included in the request.
-This header must be the base64 encoded version of:
+Most requests to cloudigrade's APIs require a custom HTTP header ``X-RH-IDENTITY`` that
+describes the caller's identity. For Red Hat "consoledot" services, this header is
+normally populated automatically by a 3scale gateway, but this document will populate
+it by using an ``HTTP_X_RH_IDENTITY`` environment variable.
+
+The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data like:
 
 
 {{ v2_rh_identity | tojson(indent=4) | rst_codeblock("json") }}

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -83,7 +83,7 @@ List all accounts
 
 Request:
 
-{{ v2_account_list.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_account_list.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -95,7 +95,7 @@ Retrieve a specific account
 
 Request:
 
-{{ v2_account_get.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_account_get.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -110,7 +110,7 @@ List all instances
 
 Request:
 
-{{ v2_instance_list.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_instance_list.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -122,7 +122,7 @@ Retrieve a specific instance
 
 Request:
 
-{{ v2_instance_get.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_instance_get.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -137,7 +137,7 @@ instances that have been running uninterrupted since the given time.
 
 Request:
 
-{{ v2_instance_filter_running.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_instance_filter_running.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -154,7 +154,7 @@ Below command will return all images that have been seen used by any instance fo
 
 Request:
 
-{{ v2_list_images.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_images.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -166,7 +166,7 @@ Retrieve a specific image
 
 Request:
 
-{{ v2_get_image.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_get_image.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -193,7 +193,7 @@ reporting period. If not defined, default is "today".
 
 Request:
 
-{{ v2_list_concurrent.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_concurrent.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -204,7 +204,7 @@ dates that not completed their calculations, the server will return ``425 Too Ea
 
 Request:
 
-{{ v2_list_concurrent_too_early.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_concurrent_too_early.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -216,7 +216,7 @@ Daily max concurrency results will end "yesterday" at the latest.
 
 Request:
 
-{{ v2_list_concurrent_partial_future.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_concurrent_partial_future.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -228,7 +228,7 @@ future dates beyond "yesterday", the API will also return a 400 with the relevan
 
 Request:
 
-{{ v2_list_concurrent_all_future.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_concurrent_all_future.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -239,7 +239,7 @@ If your requested ``end_date`` value is not greater then that of the user
 
 Request:
 
-{{ v2_list_concurrent_past_end_date.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_list_concurrent_past_end_date.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -255,7 +255,7 @@ The sysconfig endpoint includes the AWS cloud account id used by the application
 
 Request:
 
-{{ v2_get_sysconfig.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ v2_get_sysconfig.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -268,7 +268,7 @@ The Azure Offer Template endpoint returns a json template populated with current
 
 Request:
 
-{{ v2_get_azure_offer.wsgi_request | httpied_command(public=True) | rst_codeblock("bash") }}
+{{ v2_get_azure_offer.wsgi_request | httpied_command(anonymous=True) | rst_codeblock("bash") }}
 
 Response:
 
@@ -293,7 +293,7 @@ attributes are all required and should be integers.
 
 Request:
 
-{{ internal_account_create_aws.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ internal_account_create_aws.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -304,7 +304,7 @@ the system, you should get a 400 error.
 
 Request:
 
-{{ internal_account_create_aws_duplicate_arn.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ internal_account_create_aws_duplicate_arn.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -319,7 +319,7 @@ and "platform_source_id" attributes are all required and should be integers.
 
 Request:
 
-{{ internal_account_create_azure.wsgi_request | httpied_command(version=2) | rst_codeblock("bash") }}
+{{ internal_account_create_azure.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -268,7 +268,7 @@ The Azure Offer Template endpoint returns a json template populated with current
 
 Request:
 
-{{ v2_get_azure_offer.wsgi_request | httpied_command(anonymous=True) | rst_codeblock("bash") }}
+{{ v2_get_azure_offer.wsgi_request | httpied_command() | rst_codeblock("bash") }}
 
 Response:
 
@@ -324,3 +324,17 @@ Request:
 Response:
 
 {{ internal_account_create_azure | stringify_http_response | rst_codeblock }}
+
+
+Search for a user
+~~~~~~~~~~~~~~~~~
+
+To search for and retrieve a user, you may filter using "account_number", "username"
+(which simply maps to the account_number for backward compatibility), or "org_id".
+
+Request:
+
+{{ internal_user_list_filtered_by_account_number.wsgi_request |  httpied_command() | rst_codeblock("bash") }}
+
+
+{{ internal_user_list_filtered_by_account_number | stringify_http_response | rst_codeblock }}

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -50,8 +50,10 @@ The following resource paths are currently available:
 User Setup
 ------------------
 
-When accessing any endpoint with the HTTP_X_RH_IDENTITY header,
-if the user found in the header does not exist, it will not be created.
+Users are not typically created via interaction with the HTTP APIs.
+When accessing any endpoint with the ``X-RH-IDENTITY`` header,
+if the user found in the header does not exist, it will not be created,
+but not all APIs require that a corresponding cloudigrade user exists.
 
 
 Customer Account Info

--- a/openapi-internal.json
+++ b/openapi-internal.json
@@ -1169,6 +1169,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -1382,6 +1400,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -1547,6 +1583,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -1666,6 +1720,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -1848,6 +1920,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "running_since",
             "required": false,
             "in": "query",
@@ -1988,6 +2078,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -2170,6 +2278,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -2702,6 +2828,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -2946,6 +3090,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -3336,6 +3498,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -3508,6 +3688,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -4680,6 +4878,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -4834,6 +5050,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }
@@ -6146,6 +6380,24 @@
             }
           },
           {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "username",
             "required": false,
             "in": "query",
@@ -6291,6 +6543,24 @@
             "required": false,
             "in": "query",
             "description": "updated_at__gt",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account_number",
+            "required": false,
+            "in": "query",
+            "description": "account_number",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "required": false,
+            "in": "query",
+            "description": "org_id",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
Followup to https://github.com/cloudigrade/cloudigrade/pull/1253 to fix broken filters on related internal APIs.

Also closely related and included…

* add support for filtering on "account_number" and "org_id"
* improve description of X-RH-IDENTITY use in rest api examples doc
* explain alternate internal auth headers in rest api examples doc
* add example internal API call using X-CLOUDIGRADE-PSK to rest api docs