### PR TITLE
check and cache sqs queue approximate messages visible

### DIFF
--- a/cloudigrade/api/tasks/__init__.py
+++ b/cloudigrade/api/tasks/__init__.py
@@ -35,6 +35,7 @@ from api.tasks.inspection import (
     persist_inspection_cluster_results_task,
 )
 from api.tasks.maintenance import (
+    check_and_cache_sqs_queues_lengths,
     delete_cloud_account,
     delete_cloud_accounts_not_in_sources,
     delete_expired_synthetic_data,

--- a/cloudigrade/api/tests/tasks/maintenance/test_check_and_cache_sqs_queues_lengths.py
+++ b/cloudigrade/api/tests/tasks/maintenance/test_check_and_cache_sqs_queues_lengths.py
@@ -1,0 +1,139 @@
+"""Collection of tests for tasks.maintenance.check_and_cache_sqs_queues_lengths."""
+from unittest.mock import patch
+
+import faker
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from api.tasks import maintenance
+from util import aws
+
+_faker = faker.Faker()
+_base_sqs_url = "http://localhost/sqs/"
+
+
+class UnexpectedException(Exception):
+    """Dummy exception for testing."""
+
+
+def get_sqs_queue_url(queue_name):
+    """Override behavior of sqs.get_sqs_queue_url."""
+    return f"{_base_sqs_url}{queue_name}"
+
+
+class CheckAndCacheSqsQueueLengthsTest(TestCase):
+    """tasks.maintenance.check_and_cache_sqs_queues_lengths test case."""
+
+    def setUp(self):
+        """Set up common variables for tests."""
+        self.houndigrade_queue_name = f"houndigrade_{_faker.slug()}"
+        self.houndigrade_dlq_name = aws.get_sqs_queue_dlq_name(
+            self.houndigrade_queue_name
+        )
+        self.houndigrade_queue_url = get_sqs_queue_url(self.houndigrade_queue_name)
+        self.houndigrade_dlq_url = get_sqs_queue_url(self.houndigrade_dlq_name)
+
+        self.cloudtrail_queue_name = f"cloudtrail_{_faker.slug()}"
+        self.cloudtrail_dlq_name = aws.get_sqs_queue_dlq_name(
+            self.cloudtrail_queue_name
+        )
+        self.cloudtrail_queue_url = get_sqs_queue_url(self.cloudtrail_queue_name)
+        self.cloudtrail_dlq_url = get_sqs_queue_url(self.cloudtrail_dlq_name)
+
+        # It's very important to clear cache between these test runs because different
+        # tests expect values *not* to be set whereas other tests may set them.
+        cache.clear()
+
+    def test_check_and_cache_sqs_queues_lengths(self):
+        """
+        Test happy path for check_and_cache_sqs_queues_lengths.
+
+        We expect to get valid integers for all queues and to cache those values.
+        """
+        expected_counts = {
+            "houndigrade_results": _faker.random_int(),
+            "houndigrade_results_dlq": _faker.random_int(),
+            "cloudtrail_notifications": _faker.random_int(),
+            "cloudtrail_notifications_dlq": _faker.random_int(),
+        }
+
+        with override_settings(
+            HOUNDIGRADE_RESULTS_QUEUE_NAME=self.houndigrade_queue_name,
+            AWS_CLOUDTRAIL_EVENT_URL=self.cloudtrail_queue_url,
+        ), patch.object(maintenance, "aws") as mock_aws:
+            mock_aws.get_sqs_approximate_number_of_messages.side_effect = (
+                expected_counts.values()
+            )
+            # patch back in the original get_sqs_queue_dlq_name
+            mock_aws.get_sqs_queue_dlq_name = aws.get_sqs_queue_dlq_name
+            # patch back in our custom simplified get_sqs_queue_url
+            mock_aws.get_sqs_queue_url = get_sqs_queue_url
+
+            maintenance.check_and_cache_sqs_queues_lengths()
+
+        for key, value in expected_counts.items():
+            cache_key = maintenance.get_sqs_message_count_cache_key(key)
+            cache_value = cache.get(cache_key)
+            self.assertEqual(
+                value,
+                cache_value,
+                f"expected and cached values are not equal for '{key}'",
+            )
+
+    def test_check_and_cache_sqs_queues_lengths_handles_missing_queues(self):
+        """
+        Test check_and_cache_sqs_queues_lengths does not set value if missing response.
+
+        If the queue does not exist or the call to AWS raises an unexpected exception
+        or error code, we log a message and skip updating the cache for that queue.
+        """
+        # Preload the cache with an "old" value that should not be replaced.
+        old_cloudtrail_notifications_count = _faker.random_int()
+        cache.set(
+            maintenance.get_sqs_message_count_cache_key("cloudtrail_notifications"),
+            old_cloudtrail_notifications_count,
+        )
+
+        expected_counts = {
+            "houndigrade_results": _faker.random_int(),
+            "houndigrade_results_dlq": None,
+            "cloudtrail_notifications": old_cloudtrail_notifications_count,
+            "cloudtrail_notifications_dlq": _faker.random_int(),
+        }
+
+        # Slightly different list represents the responses from AWS
+        # because we want to simulate no response for "cloudtrail_notifications".
+        aws_counts = list(expected_counts.values())
+        aws_counts[2] = None
+
+        with override_settings(
+            HOUNDIGRADE_RESULTS_QUEUE_NAME=self.houndigrade_queue_name,
+            AWS_CLOUDTRAIL_EVENT_URL=self.cloudtrail_queue_url,
+        ), self.assertLogs(
+            "api.tasks.maintenance", level="ERROR"
+        ) as logging_watcher, patch.object(
+            maintenance, "aws"
+        ) as mock_aws:
+            mock_aws.get_sqs_approximate_number_of_messages.side_effect = aws_counts
+            # patch back in the original get_sqs_queue_dlq_name
+            mock_aws.get_sqs_queue_dlq_name = aws.get_sqs_queue_dlq_name
+            # patch back in our custom simplified get_sqs_queue_url
+            mock_aws.get_sqs_queue_url = get_sqs_queue_url
+
+            maintenance.check_and_cache_sqs_queues_lengths()
+
+        self.assertIn("Could not get approximate", logging_watcher.output[0])
+        self.assertIn(self.houndigrade_dlq_name, logging_watcher.output[0])
+        self.assertIn(self.houndigrade_dlq_url, logging_watcher.output[0])
+        self.assertIn("Could not get approximate", logging_watcher.output[1])
+        self.assertIn(self.cloudtrail_queue_name, logging_watcher.output[1])
+        self.assertIn(self.cloudtrail_queue_url, logging_watcher.output[1])
+
+        for key, value in expected_counts.items():
+            cache_key = maintenance.get_sqs_message_count_cache_key(key)
+            cache_value = cache.get(cache_key)
+            self.assertEqual(
+                value,
+                cache_value,
+                f"expected and cached values are not equal for '{key}'",
+            )

--- a/cloudigrade/config/celery.py
+++ b/cloudigrade/config/celery.py
@@ -26,6 +26,12 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # Remember: the "schedule" values are integer numbers of seconds.
 app.conf.beat_schedule = {
     # Enabled Tasks
+    "check_and_cache_sqs_queues_lengths": {
+        "task": "api.tasks.check_and_cache_sqs_queues_lengths",
+        "schedule": env.int(
+            "CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE", default=60 * 5
+        ),  # every 5 minutes
+    },
     "delete_inactive_users": {
         "task": "api.tasks.delete_inactive_users",
         "schedule": env.int("DELETE_INACTIVE_USERS_SCHEDULE", default=24 * 60 * 60),

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -485,6 +485,9 @@ CELERY_TASK_ROUTES = {
     "api.tasks.recalculate_runs_for_instance_id": {
         "queue": "recalculate_runs_for_instance_id"
     },
+    "api.tasks.check_and_cache_sqs_queues_lengths": {
+        "queue": "check_and_cache_sqs_queues_lengths"
+    },
     # api.tasks supporting source kafka message handling
     "api.tasks.create_from_sources_kafka_message": {
         "queue": "create_from_sources_kafka_message"
@@ -609,6 +612,11 @@ DELETE_ORPHANED_ACCOUNTS_UPDATED_MORE_THAN_SECONDS_AGO = env.int(
 # How far back should we look for CloudAccounts not in sources to delete
 DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_UPDATED_MORE_THAN_SECONDS_AGO = env.int(
     "DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_UPDATED_MORE_THAN_SECONDS_AGO", default=5 * 60
+)
+
+# How long should we keep cached SQS queue lengths (only used for metrics monitoring)
+CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL = env.int(
+    "CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL", default=30 * 60
 )
 
 # Should the internal HTTP API for SyntheticDataRequest objects be available?

--- a/cloudigrade/internal/tests/views/test_cache.py
+++ b/cloudigrade/internal/tests/views/test_cache.py
@@ -41,6 +41,24 @@ class CacheViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["value"], value)
 
+    def test_cache_get_success_with_falsy_value(self):
+        """
+        Test getting a cache key for a falsy value (int 0).
+
+        This more thoroughly exercises the "is not None" condition because we may be
+        storing falsy values like 0 in the cache, and we expect to see those correctly
+        in the internal API's responses. Previously we did not explicitly check against
+        None, and falsy values could unexpectedly return a 404 Not Found response.
+        """
+        key = _faker.word()
+        value = 0
+        cache.set(key, value)
+        request = self.factory.get(f"/cache/{key}")
+
+        response = cache_keys(request, key)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["value"], value)
+
     def test_cache_get_success_with_timeout(self):
         """Test get of a key returns the key, its value and timeout."""
         key = _faker.word()

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -347,7 +347,7 @@ def cache_keys(request, key):
     if method == "get":
         """Get a single cache key."""
         value = cache.get(key)
-        if not value:
+        if value is None:
             raise Http404
         else:
             data = {
@@ -359,7 +359,7 @@ def cache_keys(request, key):
     elif method == "post":
         """Post a single cache key."""
         value = request.data.get("value")
-        if not value:
+        if value is None:
             raise exceptions.ValidationError(detail="value field is required")
         timeout = request.data.get("timeout")
 

--- a/cloudigrade/util/aws/__init__.py
+++ b/cloudigrade/util/aws/__init__.py
@@ -46,6 +46,8 @@ from util.aws.sqs import (
     delete_messages_from_queue,
     ensure_queue_has_dlq,
     extract_sqs_message,
+    get_sqs_approximate_number_of_messages,
+    get_sqs_queue_dlq_name,
     get_sqs_queue_url,
     read_messages_from_queue,
     receive_messages_from_queue,

--- a/cloudigrade/util/aws/sqs.py
+++ b/cloudigrade/util/aws/sqs.py
@@ -217,7 +217,6 @@ def get_sqs_approximate_number_of_messages(queue_url):
         error_code = getattr(e, "response", {}).get("Error", {}).get("Code", None)
         if str(error_code).endswith(".NonExistentQueue"):
             logger.warning(_("Queue does not exist at %s"), queue_url)
-            return None
         else:
             logger.exception(
                 _(
@@ -226,7 +225,15 @@ def get_sqs_approximate_number_of_messages(queue_url):
                 ),
                 {"queue_url": queue_url, "code": error_code, "e": e},
             )
-            raise
+    except Exception as e:
+        logger.exception(
+            _(
+                "Unexpected not-ClientError exception from "
+                "get_queue_attributes using queue url: %(queue_url)s %(e)s"
+            ),
+            {"queue_url": queue_url, "e": e},
+        )
+    return None
 
 
 def create_queue(queue_name, with_dlq=True, retention_period=RETENTION_DEFAULT):

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -307,6 +307,8 @@ objects:
           value: ${DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_SCHEDULE}
         - name: DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
+        - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
+          value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: beat
@@ -562,6 +564,8 @@ objects:
           value: ${DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_SCHEDULE}
         - name: DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
+        - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
+          value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: listener
@@ -813,6 +817,8 @@ objects:
           value: ${DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_SCHEDULE}
         - name: DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
+        - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
+          value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: metrics
@@ -1135,6 +1141,8 @@ objects:
           value: ${DELETE_CLOUD_ACCOUNTS_NOT_IN_SOURCES_SCHEDULE}
         - name: DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
+        - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
+          value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
 # Secrets
@@ -1530,6 +1538,7 @@ parameters:
   value: "celery,\
     analyze_log,\
     calculate_max_concurrent_usage,\
+    check_and_cache_sqs_queues_lengths,\
     check_azure_subscription_and_create_cloud_account,\
     configure_customer_aws_and_create_cloud_account,\
     copy_ami_snapshot,\
@@ -1889,6 +1898,10 @@ parameters:
   displayName: Delete expired synthetic data schedule (seconds)
   required: true
   value: '3600'
+- name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
+  displayName: Expiration TTL for cached SQS queue lengths (seconds)
+  required: true
+  value: '1800'
 - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
   displayName: Enable the synthetic data internal HTTP API
   required: true

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -309,6 +309,8 @@ objects:
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
         - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
           value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
+        - name: CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE
+          value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: beat
@@ -566,6 +568,8 @@ objects:
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
         - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
           value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
+        - name: CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE
+          value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: listener
@@ -819,6 +823,8 @@ objects:
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
         - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
           value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
+        - name: CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE
+          value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
     - name: metrics
@@ -1143,6 +1149,8 @@ objects:
           value: ${DELETE_EXPIRED_SYNTHETIC_DATA_SCHEDULE}
         - name: CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL
           value: ${CACHED_SQS_QUEUE_LENGTH_EXPIRATION_TTL}
+        - name: CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE
+          value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
 # Secrets
@@ -1902,6 +1910,10 @@ parameters:
   displayName: Expiration TTL for cached SQS queue lengths (seconds)
   required: true
   value: '1800'
+- name: CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE
+  displayName: Check and cache SQS queue lengths schedule (seconds)
+  required: true
+  value: '300'
 - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
   displayName: Enable the synthetic data internal HTTP API
   required: true


### PR DESCRIPTION
This is the first step https://github.com/cloudigrade/cloudigrade/issues/1214 that only retrieves and caches the queue lengths. A future change will add these into the prometheus client used by the metrics exporter.

Verified in an ephemeral deployment using `CLOUDIGRADE_IMAGE_TAG=pr-1259-ba27ab6`. The `cloudigrade-beat` pod appears to be running the scheduled task:

```
2022-07-08 19:36:51,237 | INFO | 1 | beat.py:apply_entry:285 | requestid:None | Scheduler: Sending due task check_and_cache_sqs_queues_lengths (api.tasks.check_and_cache_sqs_queues_lengths)
```

and the worker appears to be executing it correctly:

```
2022-07-08 19:41:51,760 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:70bd8806-5bae-4159-9cc8-4075ceb522fe | approximate count for brasmith-ephemeral-cloudigrade-inspections-s3 is 0 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-inspections-s3)
2022-07-08 19:41:51,949 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:70bd8806-5bae-4159-9cc8-4075ceb522fe | approximate count for brasmith-ephemeral-cloudigrade-inspections-s3-dlq is 0 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-inspections-s3-dlq)
2022-07-08 19:41:52,023 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:70bd8806-5bae-4159-9cc8-4075ceb522fe | approximate count for brasmith-ephemeral-cloudigrade-cloudtrail-s3 is 0 (https://sqs.us-east-1.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-cloudtrail-s3)
2022-07-08 19:41:52,097 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:70bd8806-5bae-4159-9cc8-4075ceb522fe | approximate count for brasmith-ephemeral-cloudigrade-cloudtrail-s3-dlq is 0 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-cloudtrail-s3-dlq)
2022-07-08 19:41:52,117 | INFO | 89 | trace.py:info:131 | requestid:70bd8806-5bae-4159-9cc8-4075ceb522fe | Task api.tasks.check_and_cache_sqs_queues_lengths[baeee794-c5e3-44cb-876c-17e86f778724] succeeded in 0.6179216590098804s: None
```

Since my queues were empty, I manually added two messages to `brasmith-ephemeral-cloudigrade-cloudtrail-s3-dlq` and waited to confirm the updated count in the logs:

```
2022-07-08 19:51:51,980 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:b5598c76-0d2b-4834-b1b7-646822595d25 | approximate count for brasmith-ephemeral-cloudigrade-inspections-s3 is 0 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-inspections-s3)
2022-07-08 19:51:52,176 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:b5598c76-0d2b-4834-b1b7-646822595d25 | approximate count for brasmith-ephemeral-cloudigrade-inspections-s3-dlq is 0 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-inspections-s3-dlq)
2022-07-08 19:51:52,246 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:b5598c76-0d2b-4834-b1b7-646822595d25 | approximate count for brasmith-ephemeral-cloudigrade-cloudtrail-s3 is 0 (https://sqs.us-east-1.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-cloudtrail-s3)
2022-07-08 19:51:52,339 | INFO | 89 | maintenance.py:check_and_cache_sqs_queues_lengths:678 | requestid:b5598c76-0d2b-4834-b1b7-646822595d25 | approximate count for brasmith-ephemeral-cloudigrade-cloudtrail-s3-dlq is 2 (https://queue.amazonaws.com/xxxxxxxxxxxx/brasmith-ephemeral-cloudigrade-cloudtrail-s3-dlq)
2022-07-08 19:51:52,360 | INFO | 89 | trace.py:info:131 | requestid:b5598c76-0d2b-4834-b1b7-646822595d25 | Task api.tasks.check_and_cache_sqs_queues_lengths[5e30d931-9a61-426d-a942-ed9b1a50a762] succeeded in 0.5964780290087219s: None
```

Also confirmed that values are written to the cache by using the new internal API to get from the cache:

```
sh-4.4$ curl localhost:8000/internal/cache/sqs_message_count_cloudtrail_notifications_dlq/
{"key":"sqs_message_count_cloudtrail_notifications_dlq","value":2,"timeout":1599}
```

This PR also includes a fix for a bug I just discovered with the new internal cache HTTP API (as I was double-checking the results of my new code). If the cached value is *falsy* (like integer `0`), the internal cache HTTP API would wrongly respond with a 404. I changed its logic to look specifically for `None`, which is what `cache.get` returns when a value is not set.