### PR TITLE
update default celery-exporter-container metrics image tag to 7729ce8

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1476,7 +1476,7 @@ parameters:
 - name: CELERY_METRICS_IMAGE_TAG
   displayName: Celery Metrics Image Tag
   required: true
-  value: latest
+  value: 7729ce8
 - name: CELERY_METRICS_READINESS_TIMEOUT
   displayName: Celery Metrics readiness probe timeout in seconds
   required: true


### PR DESCRIPTION
https://github.com/cloudigrade/cloudigrade/issues/1236

- [CLOUDMETER-10](https://issues.redhat.com/browse/CLOUDMETER-10) deployment_validation_operator_latest_tag crcs02ue1
- [CLOUDMETER-15](https://issues.redhat.com/browse/CLOUDMETER-15) deployment_validation_operator_latest_tag crcp01ue1