### PR TITLE
add sqs size metrics to prometheus client

### DIFF
--- a/cloudigrade/api/tasks/maintenance.py
+++ b/cloudigrade/api/tasks/maintenance.py
@@ -26,6 +26,7 @@ from api.models import (
 )
 from api.models import User
 from util import aws
+from util.cache import get_sqs_message_count_cache_key
 from util.celery import retriable_shared_task
 from util.exceptions import AwsThrottlingException
 from util.misc import get_now, lock_task_for_user_ids
@@ -627,11 +628,6 @@ def migrate_account_numbers_to_org_ids():
             f"Failed to migrate account_numbers to org_ids - {e}", exc_info=True
         )
         return
-
-
-def get_sqs_message_count_cache_key(key):
-    """Get the cache key for an SQS queue's message count."""
-    return f"sqs_message_count_{key}"
 
 
 @shared_task(name="api.tasks.check_and_cache_sqs_queues_lengths")

--- a/cloudigrade/api/tests/tasks/maintenance/test_check_and_cache_sqs_queues_lengths.py
+++ b/cloudigrade/api/tests/tasks/maintenance/test_check_and_cache_sqs_queues_lengths.py
@@ -7,6 +7,7 @@ from django.test import TestCase, override_settings
 
 from api.tasks import maintenance
 from util import aws
+from util.cache import get_sqs_message_count_cache_key
 
 _faker = faker.Faker()
 _base_sqs_url = "http://localhost/sqs/"
@@ -72,7 +73,7 @@ class CheckAndCacheSqsQueueLengthsTest(TestCase):
             maintenance.check_and_cache_sqs_queues_lengths()
 
         for key, value in expected_counts.items():
-            cache_key = maintenance.get_sqs_message_count_cache_key(key)
+            cache_key = get_sqs_message_count_cache_key(key)
             cache_value = cache.get(cache_key)
             self.assertEqual(
                 value,
@@ -90,7 +91,7 @@ class CheckAndCacheSqsQueueLengthsTest(TestCase):
         # Preload the cache with an "old" value that should not be replaced.
         old_cloudtrail_notifications_count = _faker.random_int()
         cache.set(
-            maintenance.get_sqs_message_count_cache_key("cloudtrail_notifications"),
+            get_sqs_message_count_cache_key("cloudtrail_notifications"),
             old_cloudtrail_notifications_count,
         )
 
@@ -130,7 +131,7 @@ class CheckAndCacheSqsQueueLengthsTest(TestCase):
         self.assertIn(self.cloudtrail_queue_url, logging_watcher.output[1])
 
         for key, value in expected_counts.items():
-            cache_key = maintenance.get_sqs_message_count_cache_key(key)
+            cache_key = get_sqs_message_count_cache_key(key)
             cache_value = cache.get(cache_key)
             self.assertEqual(
                 value,

--- a/cloudigrade/internal/apps.py
+++ b/cloudigrade/internal/apps.py
@@ -3,3 +3,8 @@ from django.apps import AppConfig
 
 class InternalConfig(AppConfig):
     name = "internal"
+
+    def ready(self):
+        from internal.prometheus import initialize_cached_metrics
+
+        initialize_cached_metrics()

--- a/cloudigrade/internal/apps.py
+++ b/cloudigrade/internal/apps.py
@@ -1,10 +1,13 @@
 from django.apps import AppConfig
 
+from internal.prometheus import CachedMetricsRegistry
+
 
 class InternalConfig(AppConfig):
     name = "internal"
+    _cached_metrics_registry = None
 
     def ready(self):
-        from internal.prometheus import initialize_cached_metrics
-
-        initialize_cached_metrics()
+        if not self._cached_metrics_registry:
+            self._cached_metrics_registry = CachedMetricsRegistry()
+            self._cached_metrics_registry.initialize()

--- a/cloudigrade/internal/prometheus.py
+++ b/cloudigrade/internal/prometheus.py
@@ -1,0 +1,68 @@
+"""Custom Prometheus metrics definitions."""
+
+import logging
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+from django.core.cache import cache
+from prometheus_client import Gauge
+
+from util.cache import get_sqs_message_count_cache_key
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedGaugeMetricInfo:
+    """Describe the relationship between a cache key and Prometheus gauge metric."""
+
+    metric_name: str
+    metric_description: str
+    cache_key: str
+    default: Any
+
+
+CACHED_GAUGE_METRICS_INFO = [
+    CachedGaugeMetricInfo(
+        "houndigrade_results_message_count",
+        "approximate message count for houndigrade results queue",
+        get_sqs_message_count_cache_key("houndigrade_results"),
+        0,
+    ),
+    CachedGaugeMetricInfo(
+        "houndigrade_results_dlq_message_count",
+        "approximate message count for houndigrade results DLQ",
+        get_sqs_message_count_cache_key("houndigrade_results_dlq"),
+        0,
+    ),
+    CachedGaugeMetricInfo(
+        "cloudtrail_notifications_message_count",
+        "approximate message count for CloudTrail notifications queue",
+        get_sqs_message_count_cache_key("cloudtrail_notifications"),
+        0,
+    ),
+    CachedGaugeMetricInfo(
+        "cloudtrail_notifications_dlq_message_count",
+        "approximate message count for CloudTrail notifications DLQ",
+        get_sqs_message_count_cache_key("cloudtrail_notifications_dlq"),
+        0,
+    ),
+]
+
+CUSTOM_GAUGE_METRICS = {}
+
+
+def initialize_cached_metrics():
+    """
+    Initialize custom Prometheus metrics.
+
+    This function should only be called once at app startup.
+    """
+    if CUSTOM_GAUGE_METRICS:
+        logger.warning("Cannot reinitialize CUSTOM_GAUGE_METRICS")
+        return
+    for info in CACHED_GAUGE_METRICS_INFO:
+        gauge = Gauge(info.metric_name, info.metric_description)
+        gauge.set_function(partial(cache.get, info.cache_key, info.default))
+        CUSTOM_GAUGE_METRICS[info.metric_name] = gauge

--- a/cloudigrade/internal/tests/test_prometheus.py
+++ b/cloudigrade/internal/tests/test_prometheus.py
@@ -1,0 +1,81 @@
+"""Collection of tests for the internal.prometheus module."""
+import itertools
+from unittest.mock import patch
+
+from django.test import TestCase
+
+
+class InternalPrometheusTestCase(TestCase):
+    """
+    Test internal.prometheus.initialize_cached_metrics.
+
+    This is a difficult and strange thing to test because normally a call to
+    initialize_cached_metrics happens in InternalAppConfig.ready, but it appears to be
+    impossible (within reason) to patch that behavior so that we override or mock it
+    before Django tests actually run. Unfortunately, the AppConfig.ready functions are
+    all called long before the test classes are loaded.
+
+    So, we assume that InternalAppConfig.ready() may *already* have been called before
+    these test functions even begin their setup.
+    """
+
+    def test_initialize_cached_metrics(self):
+        """
+        Test initialize_cached_metrics creates the expected Gauge objects.
+
+        Since we assume that "ready" may already have been called, we don't actually
+        need to call initialize_cached_metrics. We just assert the expected side-effects
+        of calling initialize_cached_metrics.
+        """
+        from internal import prometheus
+        from prometheus_client import registry
+
+        self.assertEqual(
+            len(prometheus.CACHED_GAUGE_METRICS_INFO),
+            len(prometheus.CUSTOM_GAUGE_METRICS),
+        )
+
+        # Yes, _collector_to_names is pseudo-protected, but I couldn't find any other
+        # supported mechanism to list all registered collectors.
+        registered_names = itertools.chain(
+            *list(registry.REGISTRY._collector_to_names.values())
+        )
+        for info in prometheus.CACHED_GAUGE_METRICS_INFO:
+            self.assertIn(info.metric_name, registered_names)
+
+    def test_initialize_cached_metrics_multiple_calls(self):
+        """
+        Test initialize_cached_metrics only creates the Gauge objects once.
+
+        Since we assume that "ready" may already have been called, we patch two things:
+        the CUSTOM_GAUGE_METRICS dict that contains known created metrics and the
+        imported Gauge class. The former requires patching because it was already
+        populated with entries by the ready function, and the latter requires patching
+        because instantiating a new Gauge instance affects a *global* registry within
+        prometheus_client that we must not affect within the scope of a test.
+        """
+        patched_custom_gauge_metrics = {}
+        with patch(
+            "internal.prometheus.CUSTOM_GAUGE_METRICS", patched_custom_gauge_metrics
+        ), patch("internal.prometheus.Gauge") as mock_gauge:
+            from internal import prometheus
+
+            expected_final_count = len(prometheus.CACHED_GAUGE_METRICS_INFO)
+
+            # Initially CUSTOM_GAUGE_METRICS should be empty.
+            self.assertEqual(0, len(prometheus.CUSTOM_GAUGE_METRICS))
+
+            prometheus.initialize_cached_metrics()
+            # After one call, CUSTOM_GAUGE_METRICS should be fully loaded.
+            self.assertEqual(expected_final_count, len(prometheus.CUSTOM_GAUGE_METRICS))
+            self.assertEqual(expected_final_count, mock_gauge.call_count)
+
+            metrics_after_first_call = prometheus.CUSTOM_GAUGE_METRICS.copy()
+            mock_gauge.reset_mock()
+
+            prometheus.initialize_cached_metrics()
+            # After the second call, CUSTOM_GAUGE_METRICS should be unchanged,
+            # and there should be no more Gauge calls.
+            self.assertEqual(expected_final_count, len(prometheus.CUSTOM_GAUGE_METRICS))
+            self.assertEqual(metrics_after_first_call, prometheus.CUSTOM_GAUGE_METRICS)
+            self.assertEqual(0, mock_gauge.call_count)

--- a/cloudigrade/util/cache.py
+++ b/cloudigrade/util/cache.py
@@ -22,3 +22,8 @@ def get_cache_key_timeout(key):
         return 0
     delta = expiration_date_time - now
     return delta.seconds
+
+
+def get_sqs_message_count_cache_key(key):
+    """Get the cache key for an SQS queue's message count."""
+    return f"sqs_message_count_{key}"


### PR DESCRIPTION
For https://github.com/cloudigrade/cloudigrade/issues/1214, add the newly cached SQS sizes from https://github.com/cloudigrade/cloudigrade/pull/1259 to be exported to the Prometheus client's metrics endpoint.

For context, I'm calling the new code in the `ready` function because I want it:
* called at app startup
* only called once
* called explicitly

This introduces some challenges to testing, though. Definitely read the docstrings in the tests to understand why the tests are written as they are. It feels kind of weird, but it totally works. 🙂 I'm happy to try out better alternatives if you can think of any.

Running cloudigrade locally with a couple messages in my DLQs, after running the `check_and_cache_sqs_queues_lengths` task, my `/internal/metrics` endpoint now includes…

```
❯ http localhost:8080/internal/metrics | grep message_count
# HELP houndigrade_results_message_count approximate message count for houndigrade results queue
# TYPE houndigrade_results_message_count gauge
houndigrade_results_message_count 0.0
# HELP houndigrade_results_dlq_message_count approximate message count for houndigrade results DLQ
# TYPE houndigrade_results_dlq_message_count gauge
houndigrade_results_dlq_message_count 1.0
# HELP cloudtrail_notifications_message_count approximate message count for CloudTrail notifications queue
# TYPE cloudtrail_notifications_message_count gauge
cloudtrail_notifications_message_count 0.0
# HELP cloudtrail_notifications_dlq_message_count approximate message count for CloudTrail notifications DLQ
# TYPE cloudtrail_notifications_dlq_message_count gauge
cloudtrail_notifications_dlq_message_count 2.0
```