### PR TITLE
Fix user cloudaccount race condition

### DIFF
--- a/cloudigrade/api/clouds/aws/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/aws/tasks/onboarding.py
@@ -51,9 +51,36 @@ def configure_customer_aws_and_create_cloud_account(
         application_id (str): Platform Sources' Application object id
         source_id (str): Platform Sources' Source object id
     """
+    logger.info(
+        _(
+            "Starting configure_customer_aws_and_create_cloud_account for "
+            "username='%(username)s' "
+            "org_id='%(org_id)s' "
+            "customer_arn='%(customer_arn)s' "
+            "authentication_id='%(authentication_id)s' "
+            "application_id='%(application_id)s' "
+            "source_id='%(source_id)s'"
+        ),
+        {
+            "username": username,
+            "org_id": org_id,
+            "customer_arn": customer_arn,
+            "authentication_id": authentication_id,
+            "application_id": application_id,
+            "source_id": source_id,
+        },
+    )
     try:
         user = get_user_by_account(account_number=username, org_id=org_id)
     except User.DoesNotExist:
+        logger.exception(
+            _(
+                "Missing user (account_number='%(username)s', org_id='%(org_id)s') "
+                "for configure_customer_aws_and_create_cloud_account. "
+                "This should never happen and may indicate a database failure!"
+            ),
+            {"username": username, "org_id": org_id},
+        )
         error = error_codes.CG1000
         error.log_internal_message(
             logger, {"application_id": application_id, "username": username}

--- a/cloudigrade/api/clouds/azure/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/azure/tasks/onboarding.py
@@ -29,9 +29,36 @@ def check_azure_subscription_and_create_cloud_account(
         application_id (str): Platform Sources' Application object id
         source_id (str): Platform Sources' Source object id
     """
+    logger.info(
+        _(
+            "Starting check_azure_subscription_and_create_cloud_account for "
+            "username='%(username)s' "
+            "org_id='%(org_id)s' "
+            "subscription_id='%(subscription_id)s' "
+            "authentication_id='%(authentication_id)s' "
+            "application_id='%(application_id)s' "
+            "source_id='%(source_id)s'"
+        ),
+        {
+            "username": username,
+            "org_id": org_id,
+            "subscription_id": subscription_id,
+            "authentication_id": authentication_id,
+            "application_id": application_id,
+            "source_id": source_id,
+        },
+    )
     try:
         user = get_user_by_account(account_number=username, org_id=org_id)
     except User.DoesNotExist:
+        logger.exception(
+            _(
+                "Missing user (account_number='%(username)s', org_id='%(org_id)s') "
+                "for check_azure_subscription_and_create_cloud_account. "
+                "This should never happen and may indicate a database failure!"
+            ),
+            {"username": username, "org_id": org_id},
+        )
         error = error_codes.CG1000
         error.log_internal_message(
             logger, {"application_id": application_id, "username": username}

--- a/cloudigrade/api/tests/clouds/aws/tasks/onboarding/test_configure_customer_aws_and_create_cloud_account.py
+++ b/cloudigrade/api/tests/clouds/aws/tasks/onboarding/test_configure_customer_aws_and_create_cloud_account.py
@@ -151,4 +151,4 @@ class ConfigureCustomerAwsAndCreateCloudAccountTest(TestCase):
                 application_id,
                 source_id,
             )
-        self.assertIn("Invalid ARN.", cm.output[1])
+        self.assertIn("Invalid ARN.", cm.output[2])

--- a/cloudigrade/api/tests/tasks/sources/test_create_from_sources_kafka_message.py
+++ b/cloudigrade/api/tests/tasks/sources/test_create_from_sources_kafka_message.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import faker
 from django.conf import settings
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from api.models import User
 from api.tasks import sources
@@ -14,7 +14,7 @@ from util.tests import helper as util_helper
 _faker = faker.Faker()
 
 
-class CreateFromSourcesKafkaMessageTest(TestCase):
+class CreateFromSourcesKafkaMessageTest(TransactionTestCase):
     """Celery task 'create_from_sources_kafka_message' test cases."""
 
     def setUp(self):


### PR DESCRIPTION
In rare circumstances when cloudigrade's database connection is degraded or failing, I believe it's possible for a task to try to create a cloud account when its preceding task to create its user has not committed its transaction. In this case, the latter task may fail because it needs the user and expects that the former task has created the user. I believe this happened during a production cluster upgrade on 2022-07-20 when DNS was failing and we were losing database connections unexpectedly ([Slack thread here](https://ansible.slack.com/archives/C8VGAPJNN/p1658343725061179?thread_ts=1658337496.274419&cid=C8VGAPJNN)).

This PR makes a couple of changes:

1. It moves some logic into `transaction.on_commit` to avoid the race condition.
2. It adds more logs to help diagnose this or related issues in the future.