### PR TITLE
pr_check.sh: stop using deprecated value format

### DIFF
--- a/deployment/scripts/pr_check.sh
+++ b/deployment/scripts/pr_check.sh
@@ -43,8 +43,8 @@ bonfire deploy \
     ${APP_NAME} \
     --source=appsre \
     --ref-env insights-stage \
-    --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
-    --set-template-ref ${APP_NAME}/postigrade=master \
+    --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
+    --set-template-ref postigrade=master \
     --set-image-tag ${IMAGE}=${IMAGE_TAG} \
     --namespace ${NAMESPACE} \
     --timeout ${DEPLOY_TIMEOUT} \


### PR DESCRIPTION
During demo done by Parag, I noticed deprecated warning in pr-check job logs:

    --set-template-ref: <app>/<component>=<ref> syntax is deprecated, use <component>=<ref>

This change was introduced back in 2021 in https://github.com/RedHatInsights/bonfire/pull/44/ . Component names are unique across the whole config, so there's no point in namespacing components by app names - `foo/foo=bar` and `foo=bar` are supposedly equivalent.

I guess CI results from this PR will tell if this change is really safe to merge.