### PR TITLE
add internal api to execute raw redis commands

### DIFF
--- a/cloudigrade/internal/encoders.py
+++ b/cloudigrade/internal/encoders.py
@@ -1,0 +1,16 @@
+"""Custom DRF encoders."""
+from rest_framework.utils.encoders import JSONEncoder
+
+
+class JsonBytesEncoder(JSONEncoder):
+    """Custom JSON encoder that converts un-decodable byte objects to "b" strings."""
+
+    def default(self, obj):
+        """Extend JSONEncoder.default to gracefully handle not-utf-8 byte objects."""
+        if isinstance(obj, bytes):
+            try:
+                return obj.decode()
+            except UnicodeDecodeError:
+                return str(obj)
+        else:
+            return super().default(obj)

--- a/cloudigrade/internal/renderers.py
+++ b/cloudigrade/internal/renderers.py
@@ -1,0 +1,10 @@
+"""Custom DRF renderers."""
+from rest_framework.renderers import JSONRenderer
+
+from internal.encoders import JsonBytesEncoder
+
+
+class JsonBytesRenderer(JSONRenderer):
+    """Custom JSON renderer that renders byte objects as strings."""
+
+    encoder_class = JsonBytesEncoder

--- a/cloudigrade/internal/serializers.py
+++ b/cloudigrade/internal/serializers.py
@@ -3,8 +3,8 @@ from django.utils.translation import gettext as _
 from django_celery_beat.models import PeriodicTask
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, CharField
-from rest_framework.serializers import ModelSerializer
+from rest_framework.fields import BooleanField, CharField, ChoiceField
+from rest_framework.serializers import ModelSerializer, Serializer
 
 from api import models
 from api.clouds.aws import models as aws_models
@@ -324,3 +324,21 @@ class InternalSyntheticDataRequestSerializer(ModelSerializer):
         if errors:
             raise ValidationError(errors)
         return super().update(instance, validated_data)
+
+
+class InternalRedisRawInputSerializer(Serializer):
+    """Serializer to validate input for the internal redis_raw API."""
+
+    allowed_commands = [
+        "keys",  # find all keys matching the given pattern
+        "type",  # get the type of a key
+        "get",  # get the value of a key
+        "llen",  # get the length of a list
+        "lrange",  # get a range of elements from a list
+        "scard",  # get the number of members in a set
+        "smembers",  # list members of the set with the given key
+        "sismember",  # determine if a given value is a member of a set
+    ]
+
+    command = ChoiceField(allowed_commands, required=True)
+    args = CharField(required=True, min_length=1)

--- a/cloudigrade/internal/tests/views/test_redis_raw.py
+++ b/cloudigrade/internal/tests/views/test_redis_raw.py
@@ -1,0 +1,110 @@
+"""Collection of tests for internal Redis raw command API."""
+import json
+from unittest.mock import patch
+
+import faker
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from internal.serializers import InternalRedisRawInputSerializer
+from internal.views import redis_raw
+
+_faker = faker.Faker()
+
+
+class RedisRawViewTest(TestCase):
+    """Redis raw command API view test case."""
+
+    def setUp(self):
+        """Set up shared test data."""
+        self.factory = APIRequestFactory()
+        get_redis_connection_patch = patch("internal.views.get_redis_connection")
+        mock_get_redis_connection = get_redis_connection_patch.start()
+        self.mock_connection = (
+            mock_get_redis_connection.return_value.__enter__.return_value
+        )
+        self.addCleanup(get_redis_connection_patch.stop)
+
+    def assertExpectedJsonResponse(self, response, expected):
+        """Assert expected is equal to response rendered as JSON."""
+        response.render()
+        response_json_decoded = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(response_json_decoded, expected)
+
+    def test_supported_command_and_args(self):
+        """Test happy path success for running a command with args."""
+        command = _faker.random_element(
+            InternalRedisRawInputSerializer.allowed_commands
+        )
+        args = _faker.word()
+        request = self.factory.post(
+            "/redis_raw/", data={"command": command, "args": args}, format="json"
+        )
+
+        redis_command_results = _faker.sentence()
+        mock_func = getattr(self.mock_connection, command)
+        mock_func.return_value = redis_command_results
+
+        expected_response_data = {"results": redis_command_results}
+
+        response = redis_raw(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertExpectedJsonResponse(response, expected_response_data)
+
+    def test_unsupported_command_fails(self):
+        """Test failure path for an unsupported command."""
+        command = _faker.word()
+        args = _faker.word()
+        request = self.factory.post(
+            "/redis_raw/", data={"command": command, "args": args}, format="json"
+        )
+
+        redis_command_results = _faker.sentence()
+        mock_func = getattr(self.mock_connection, command)
+        mock_func.return_value = redis_command_results
+
+        expected_response_data = {"command": [f'"{command}" is not a valid choice.']}
+
+        response = redis_raw(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertExpectedJsonResponse(response, expected_response_data)
+
+    def test_invalid_argument_fails(self):
+        """Test failure path for invalid arguments to the command."""
+        command = _faker.random_element(
+            InternalRedisRawInputSerializer.allowed_commands
+        )
+        args = _faker.word()
+        request = self.factory.post(
+            "/redis_raw/", data={"command": command, "args": args}, format="json"
+        )
+
+        error = TypeError()
+        mock_func = getattr(self.mock_connection, command)
+        mock_func.side_effect = error
+
+        expected_response_data = {"error": str(error)}
+
+        response = redis_raw(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertExpectedJsonResponse(response, expected_response_data)
+
+    def test_result_bytes_are_stringified(self):
+        """Test a command's returned not-utf-8 bytes are stringified as expected."""
+        command = _faker.random_element(
+            InternalRedisRawInputSerializer.allowed_commands
+        )
+        args = _faker.word()
+        request = self.factory.post(
+            "/redis_raw/", data={"command": command, "args": args}, format="json"
+        )
+
+        redis_command_results = b"\xa0\x69"  # 0xa0 in position 0: invalid start byte
+        mock_func = getattr(self.mock_connection, command)
+        mock_func.return_value = redis_command_results
+
+        expected_response_data = {"results": "b'\\xa0i'"}
+
+        response = redis_raw(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertExpectedJsonResponse(response, expected_response_data)

--- a/cloudigrade/internal/urls.py
+++ b/cloudigrade/internal/urls.py
@@ -120,6 +120,7 @@ urlpatterns += [
         name="internal-recalculate-concurrent-usage",
     ),
     path("recalculate_runs/", views.recalculate_runs, name="internal-recalculate-runs"),
+    path("redis_raw/", views.redis_raw, name="internal-redis-raw"),
     path("sources_kafka/", views.sources_kafka, name="internal-sources-kafka"),
 ]
 


### PR DESCRIPTION
Since we don't have direct access to Redis in our stage and deployments, this new internal API can aid with investigations and troubleshooting. For this initial implementation, I only allow a few non-destructive read-only commands. I would welcome expanding this functionality in the future as needs arise (or maybe refactoring it out into a separate tool of its own), but I'd like to start by keeping it simple and playing it safe.

Example calls and results:

```
❯ http localhost:8080/internal/redis_raw/ \
  command="keys" args="brasmith-local-cloudigrade*"
HTTP/1.1 200 OK
Allow: OPTIONS, POST
Content-Length: 563
Content-Type: application/json
Date: Fri, 22 Jul 2022 18:42:21 GMT
Referrer-Policy: same-origin
Server: WSGIServer/0.2 CPython/3.9.7
X-CLOUDIGRADE-REQUEST-ID: 81455dd5-fb2b-4a64-8cb4-89751b0f2077
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{
    "results": [
        "brasmith-local-cloudigrade:1:sqs_message_count_cloudtrail_notifications",
        "brasmith-local-cloudigrade:1:fc88b696384e7e0f08ff9865b4ea7c8c",
        "brasmith-local-cloudigrade:1:sqs_message_count_houndigrade_results_dlq",
        "brasmith-local-cloudigrade:1:sqs_message_count_houndigrade_results",
        "brasmith-local-cloudigrade:1:e6855f155fb583403c3bd83d8ae92d63",
        "brasmith-local-cloudigrade:1:9074e6b9dd5a55ee7fd1b5658be77914",
        "brasmith-local-cloudigrade:1:a158db0c789c326772c9b21f0be75ade",
        "brasmith-local-cloudigrade:1:sqs_message_count_cloudtrail_notifications_dlq"
    ]
}
```

```
❯ http localhost:8080/internal/redis_raw/ \
  command="smembers" args="brasmith-local-_kombu.binding.celery"
HTTP/1.1 200 OK
Allow: OPTIONS, POST
Content-Length: 52
Content-Type: application/json
Date: Fri, 22 Jul 2022 18:42:42 GMT
Referrer-Policy: same-origin
Server: WSGIServer/0.2 CPython/3.9.7
X-CLOUDIGRADE-REQUEST-ID: 1daa3eb1-7efb-411c-9700-401ede122378
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{
    "results": [
        "celery\u0006\u0016\u0006\u0016celery"
    ]
}
```

```
❯ http localhost:8080/internal/redis_raw/ \
  command="lrange" args="brasmith-local-check_and_cache_sqs_queues_lengths 0 1"
HTTP/1.1 200 OK
Allow: OPTIONS, POST
Content-Length: 2209
Content-Type: application/json
Date: Fri, 22 Jul 2022 18:49:20 GMT
Referrer-Policy: same-origin
Server: WSGIServer/0.2 CPython/3.9.7
X-CLOUDIGRADE-REQUEST-ID: 2a5f699a-8999-499c-a415-e389846ecdb0
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{
    "results": [
        "{\"body\": \"W1tdLCB7fSwgeyJjYWxsYmFja3MiOiBudWxsLCAiZXJyYmFja3MiOiBudWxsLCAiY2hhaW4iOiBudWxsLCAiY2hvcmQiOiBudWxsfV0=\", \"content-encoding\": \"utf-8\", \"content-type\": \"application/json\", \"headers\": {\"lang\": \"py\", \"task\": \"api.tasks.check_and_cache_sqs_queues_lengths\", \"id\": \"43bbbb7d-4905-41e2-86e0-d5b996c16139\", \"shadow\": null, \"eta\": null, \"expires\": null, \"group\": null, \"group_index\": null, \"retries\": 0, \"timelimit\": [null, null], \"root_id\": \"43bbbb7d-4905-41e2-86e0-d5b996c16139\", \"parent_id\": null, \"argsrepr\": \"()\", \"kwargsrepr\": \"{}\", \"origin\": \"gen34902@brasmith-shadowbook.local\", \"ignore_result\": false, \"request_id\": \"7aaa47ff-9991-42b0-ada7-c5133d5d5186\"}, \"properties\": {\"correlation_id\": \"43bbbb7d-4905-41e2-86e0-d5b996c16139\", \"reply_to\": \"9cb34d37-5498-381f-bbdc-9dd4b49e2ca8\", \"delivery_mode\": 2, \"delivery_info\": {\"exchange\": \"\", \"routing_key\": \"check_and_cache_sqs_queues_lengths\"}, \"priority\": 0, \"body_encoding\": \"base64\", \"delivery_tag\": \"df840516-94dc-49ce-be99-224280d915ba\"}}",
        "{\"body\": \"W1tdLCB7fSwgeyJjYWxsYmFja3MiOiBudWxsLCAiZXJyYmFja3MiOiBudWxsLCAiY2hhaW4iOiBudWxsLCAiY2hvcmQiOiBudWxsfV0=\", \"content-encoding\": \"utf-8\", \"content-type\": \"application/json\", \"headers\": {\"lang\": \"py\", \"task\": \"api.tasks.check_and_cache_sqs_queues_lengths\", \"id\": \"da177d65-6b05-4682-986d-9ba37f5e745e\", \"shadow\": null, \"eta\": null, \"expires\": null, \"group\": null, \"group_index\": null, \"retries\": 0, \"timelimit\": [null, null], \"root_id\": \"da177d65-6b05-4682-986d-9ba37f5e745e\", \"parent_id\": null, \"argsrepr\": \"()\", \"kwargsrepr\": \"{}\", \"origin\": \"gen34902@brasmith-shadowbook.local\", \"ignore_result\": false, \"request_id\": \"dc678006-41c5-491c-8c82-334a34441faa\"}, \"properties\": {\"correlation_id\": \"da177d65-6b05-4682-986d-9ba37f5e745e\", \"reply_to\": \"9cb34d37-5498-381f-bbdc-9dd4b49e2ca8\", \"delivery_mode\": 2, \"delivery_info\": {\"exchange\": \"\", \"routing_key\": \"check_and_cache_sqs_queues_lengths\"}, \"priority\": 0, \"body_encoding\": \"base64\", \"delivery_tag\": \"c184ba2d-f5e3-477d-804e-84c52543e972\"}}"
    ]
}
```

```
❯ http localhost:8080/internal/redis_raw/ \
  command="lrange" args="brasmith-local-check_and_cache_sqs_queues_lengths 0 0" | \
  jq -r ".results[0]" | jq
{
  "body": "W1tdLCB7fSwgeyJjYWxsYmFja3MiOiBudWxsLCAiZXJyYmFja3MiOiBudWxsLCAiY2hhaW4iOiBudWxsLCAiY2hvcmQiOiBudWxsfV0=",
  "content-encoding": "utf-8",
  "content-type": "application/json",
  "headers": {
    "lang": "py",
    "task": "api.tasks.check_and_cache_sqs_queues_lengths",
    "id": "43bbbb7d-4905-41e2-86e0-d5b996c16139",
    "shadow": null,
    "eta": null,
    "expires": null,
    "group": null,
    "group_index": null,
    "retries": 0,
    "timelimit": [
      null,
      null
    ],
    "root_id": "43bbbb7d-4905-41e2-86e0-d5b996c16139",
    "parent_id": null,
    "argsrepr": "()",
    "kwargsrepr": "{}",
    "origin": "gen34902@brasmith-shadowbook.local",
    "ignore_result": false,
    "request_id": "7aaa47ff-9991-42b0-ada7-c5133d5d5186"
  },
  "properties": {
    "correlation_id": "43bbbb7d-4905-41e2-86e0-d5b996c16139",
    "reply_to": "9cb34d37-5498-381f-bbdc-9dd4b49e2ca8",
    "delivery_mode": 2,
    "delivery_info": {
      "exchange": "",
      "routing_key": "check_and_cache_sqs_queues_lengths"
    },
    "priority": 0,
    "body_encoding": "base64",
    "delivery_tag": "df840516-94dc-49ce-be99-224280d915ba"
  }
}
```

```
❯ http localhost:8080/internal/redis_raw/ \
  command="type" args="brasmith-local-cloudigrade:1:fc88b696384e7e0f08ff9865b4ea7c8c"
HTTP/1.1 200 OK
Allow: OPTIONS, POST
Content-Length: 20
Content-Type: application/json
Date: Fri, 22 Jul 2022 18:51:28 GMT
Referrer-Policy: same-origin
Server: WSGIServer/0.2 CPython/3.9.7
X-CLOUDIGRADE-REQUEST-ID: 9423db19-4b69-4574-87da-2e07d5475df8
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

{
    "results": "string"
}
```