### PR TITLE
custom celery metrics

### DIFF
--- a/cloudigrade/internal/prometheus.py
+++ b/cloudigrade/internal/prometheus.py
@@ -5,9 +5,11 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
+from django.conf import settings
 from django.core.cache import cache
 from prometheus_client import Gauge
 
+from internal import redis
 from util.cache import get_sqs_message_count_cache_key
 
 logger = logging.getLogger(__name__)
@@ -50,6 +52,8 @@ CACHED_GAUGE_METRICS_INFO = [
     ),
 ]
 
+CELERY_QUEUE_LENGTH_METRIC_NAME = "cloudigrade_celery_queue_length"
+
 
 class CachedMetricsRegistry:
     """
@@ -71,10 +75,38 @@ class CachedMetricsRegistry:
         if self._gauge_metrics:
             logger.warning("Cannot reinitialize gauge metrics")
             return
+        self._initialize_cached_metrics()
+        self._initialize_celery_queue_length_metrics()
+
+    def _initialize_cached_metrics(self):
+        """Initialize cached metrics."""
         for info in CACHED_GAUGE_METRICS_INFO:
             gauge = Gauge(info.metric_name, info.metric_description)
             gauge.set_function(partial(cache.get, info.cache_key, info.default))
             self._gauge_metrics[info.metric_name] = gauge
+
+    def _initialize_celery_queue_length_metrics(self):
+        """Initialize Celery queue length metrics."""
+        if not redis.redis_is_the_default_cache():
+            # Currently this function only supports the Redis backend.
+            return
+
+        gauge = Gauge(
+            CELERY_QUEUE_LENGTH_METRIC_NAME,
+            "The number of messages in Celery broker queue.",
+            labelnames=["queue_name"],
+        )
+        self._gauge_metrics[CELERY_QUEUE_LENGTH_METRIC_NAME] = gauge
+
+        task_prefix = settings.CELERY_BROKER_TRANSPORT_OPTIONS.get(
+            "global_keyprefix", ""
+        )
+        for task_route in settings.CELERY_TASK_ROUTES.values():
+            if task_queue := task_route.get("queue"):
+                queue_name = f"{task_prefix}{task_queue}"
+                gauge.labels(queue_name=task_queue).set_function(
+                    partial(redis.execute_command, "llen", [queue_name])
+                )
 
     def get_registered_metrics_names(self):
         """Get list of registered metrics names."""

--- a/cloudigrade/internal/redis.py
+++ b/cloudigrade/internal/redis.py
@@ -1,5 +1,7 @@
 """Internal Redis helper functions."""
+from django.core.cache import caches
 from django_redis import get_redis_connection
+from django_redis.cache import RedisCache
 
 
 def execute_command(command, args):
@@ -8,3 +10,8 @@ def execute_command(command, args):
         func = getattr(connection, command)
         results = func(*args)
     return results
+
+
+def redis_is_the_default_cache():
+    """Check if Redis is the default cache."""
+    return isinstance(caches["default"], RedisCache)

--- a/cloudigrade/internal/redis.py
+++ b/cloudigrade/internal/redis.py
@@ -1,0 +1,10 @@
+"""Internal Redis helper functions."""
+from django_redis import get_redis_connection
+
+
+def execute_command(command, args):
+    """Execute a Redis command."""
+    with get_redis_connection("default") as connection:
+        func = getattr(connection, command)
+        results = func(*args)
+    return results

--- a/cloudigrade/internal/tests/test_prometheus.py
+++ b/cloudigrade/internal/tests/test_prometheus.py
@@ -10,32 +10,31 @@ _faker = faker.Faker()
 
 class InternalPrometheusTestCase(TestCase):
     """
-    Test internal.prometheus.initialize_cached_metrics.
+    Test internal.prometheus.CachedMetricsRegistry.
 
-    This is a difficult and strange thing to test because normally a call to
-    initialize_cached_metrics happens in InternalAppConfig.ready, but it appears to be
-    impossible (within reason) to patch that behavior so that we override or mock it
-    before Django tests actually run. Unfortunately, the AppConfig.ready functions are
-    all called long before the test classes are loaded.
+    This is a difficult and strange thing to test because normally a call to initialize
+    happens in InternalAppConfig.ready, but it appears to be impossible (within reason)
+    to patch that behavior so that we override or mock it before Django tests actually
+    run. Unfortunately, the AppConfig.ready functions are all called long before the
+    test classes are loaded.
 
     So, we assume that InternalAppConfig.ready() may *already* have been called before
     these test functions even begin their setup.
     """
 
-    def test_initialize_cached_metrics(self):
+    def test_initialize(self):
         """
-        Test initialize_cached_metrics creates the expected Gauge objects.
+        Test initialize creates the expected Gauge object.
 
         Since we assume that "ready" may already have been called, we don't actually
-        need to call initialize_cached_metrics. We just assert the expected side-effects
-        of calling initialize_cached_metrics.
+        need to call initialize. We just assert the expected side-effects of calling
+        initialize.
         """
         from internal import prometheus
         from prometheus_client import registry
 
         self.assertEqual(
-            len(prometheus.CACHED_GAUGE_METRICS_INFO),
-            len(prometheus.CachedMetricsRegistry().get_registered_metrics_names()),
+            len(prometheus.CachedMetricsRegistry().get_registered_metrics_names()), 1
         )
 
         # Yes, _collector_to_names is pseudo-protected, but I couldn't find any other
@@ -43,12 +42,19 @@ class InternalPrometheusTestCase(TestCase):
         registered_names = itertools.chain(
             *list(registry.REGISTRY._collector_to_names.values())
         )
-        for info in prometheus.CACHED_GAUGE_METRICS_INFO:
-            self.assertIn(info.metric_name, registered_names)
+        self.assertIn(prometheus.CACHED_SQS_QUEUE_LENGTH_METRIC_NAME, registered_names)
+        # Ditto for _names_to_collectors being protected. I wish I could find a better
+        # supported mechanism to access the registry's internals.
+        individual_metrics = registry.REGISTRY._names_to_collectors[
+            prometheus.CACHED_SQS_QUEUE_LENGTH_METRIC_NAME
+        ]._metrics
+        self.assertEqual(
+            len(individual_metrics), len(prometheus.CACHED_SQS_QUEUE_LENGTH_LABELS)
+        )
 
-    def test_initialize_cached_metrics_multiple_calls(self):
+    def test_initialize_multiple_calls(self):
         """
-        Test initialize_cached_metrics only creates the Gauge objects once.
+        Test initialize only creates the Gauge object once.
 
         Since we assume that "ready" may already have been called, we patch two things:
         the _gauge_metrics dict that contains known created metrics and the
@@ -64,8 +70,6 @@ class InternalPrometheusTestCase(TestCase):
         ), patch("internal.prometheus.Gauge") as mock_gauge:
             from internal import prometheus
 
-            expected_final_count = len(prometheus.CACHED_GAUGE_METRICS_INFO)
-
             registry = prometheus.CachedMetricsRegistry()
 
             # Initially _gauge_metrics should be empty.
@@ -73,9 +77,9 @@ class InternalPrometheusTestCase(TestCase):
 
             registry.initialize()
             metrics_after_first_call = registry.get_registered_metrics_names()
-            # After one call, _gauge_metrics should be fully loaded.
-            self.assertEqual(expected_final_count, len(metrics_after_first_call))
-            self.assertEqual(expected_final_count, mock_gauge.call_count)
+            # After one call, _gauge_metrics should be populated.
+            self.assertEqual(1, len(metrics_after_first_call))
+            mock_gauge.assert_called_once()
 
             mock_gauge.reset_mock()
 
@@ -83,9 +87,9 @@ class InternalPrometheusTestCase(TestCase):
             # After the second call, _gauge_metrics should be unchanged,
             # and there should be no more Gauge calls.
             metrics_after_second_call = registry.get_registered_metrics_names()
-            self.assertEqual(expected_final_count, len(metrics_after_second_call))
+            self.assertEqual(1, len(metrics_after_second_call))
             self.assertEqual(metrics_after_first_call, metrics_after_second_call)
-            self.assertEqual(0, mock_gauge.call_count)
+            mock_gauge.assert_not_called()
 
     def test_initialize_celery_queue_length_metrics(self):
         """

--- a/cloudigrade/internal/tests/test_prometheus.py
+++ b/cloudigrade/internal/tests/test_prometheus.py
@@ -1,8 +1,11 @@
 """Collection of tests for the internal.prometheus module."""
 import itertools
-from unittest.mock import patch
+from unittest.mock import call, patch
 
-from django.test import TestCase
+import faker
+from django.test import TestCase, override_settings
+
+_faker = faker.Faker()
 
 
 class InternalPrometheusTestCase(TestCase):
@@ -83,3 +86,45 @@ class InternalPrometheusTestCase(TestCase):
             self.assertEqual(expected_final_count, len(metrics_after_second_call))
             self.assertEqual(metrics_after_first_call, metrics_after_second_call)
             self.assertEqual(0, mock_gauge.call_count)
+
+    def test_initialize_celery_queue_length_metrics(self):
+        """
+        Test Celery queue length metrics are created as expected.
+
+        Normally the _initialize_celery_queue_length_metrics function never completes
+        full execution by unit tests because unit tests are not configured to use the
+        Redis cache backend. This test short-circuits Redis detection to make metrics
+        initialization possible.
+        """
+        fake_celery_task_routes = {
+            _faker.slug(): {"queue": _faker.slug()},
+            _faker.slug(): {"queue": _faker.slug()},
+        }
+        expected_labels_calls = [
+            call(queue_name=info["queue"]) for info in fake_celery_task_routes.values()
+        ]
+
+        patched_custom_gauge_metrics = {}
+        with patch(
+            "internal.prometheus.CachedMetricsRegistry._gauge_metrics",
+            patched_custom_gauge_metrics,
+        ), patch("internal.prometheus.Gauge") as mock_gauge, patch(
+            "internal.prometheus.redis.redis_is_the_default_cache"
+        ) as mock_redis_is_cache, override_settings(
+            CELERY_TASK_ROUTES=fake_celery_task_routes
+        ):
+            mock_redis_is_cache.return_value = True
+
+            from internal import prometheus
+
+            registry = prometheus.CachedMetricsRegistry()
+            registry._initialize_celery_queue_length_metrics()
+            self.assertIn(
+                prometheus.CELERY_QUEUE_LENGTH_METRIC_NAME,
+                registry.get_registered_metrics_names(),
+            )
+            mock_gauge.assert_called_once()
+            mock_gauge_instance = mock_gauge.return_value
+            actual_labels_calls = mock_gauge_instance.labels.mock_calls
+            for expected_labels_call in expected_labels_calls:
+                self.assertIn(expected_labels_call, actual_labels_calls)

--- a/cloudigrade/internal/tests/views/test_redis_raw.py
+++ b/cloudigrade/internal/tests/views/test_redis_raw.py
@@ -18,7 +18,7 @@ class RedisRawViewTest(TestCase):
     def setUp(self):
         """Set up shared test data."""
         self.factory = APIRequestFactory()
-        get_redis_connection_patch = patch("internal.views.get_redis_connection")
+        get_redis_connection_patch = patch("internal.views.redis.get_redis_connection")
         mock_get_redis_connection = get_redis_connection_patch.start()
         self.mock_connection = (
             mock_get_redis_connection.return_value.__enter__.return_value


### PR DESCRIPTION
Add custom Celery queue length metrics (using raw Redis connection commands) and refactor the recently added SQS metrics into one metric with multiple labels.

I'm specifically prefixing these metrics names with `cloudigrade_` to avoid colliding with similar names from common metrics exporting libraries.

Example of current metrics output on a local sandbox:
```
❯ http localhost:8080/internal/metrics | grep queue_length
# HELP cloudigrade_sqs_queue_length The approximate number of messages in AWS SQS queue.
# TYPE cloudigrade_sqs_queue_length gauge
cloudigrade_sqs_queue_length{queue_name="houndigrade_results"} 0.0
cloudigrade_sqs_queue_length{queue_name="houndigrade_results_dlq"} 1.0
cloudigrade_sqs_queue_length{queue_name="cloudtrail_notifications"} 0.0
cloudigrade_sqs_queue_length{queue_name="cloudtrail_notifications_dlq"} 2.0
# HELP cloudigrade_celery_queue_length The number of messages in Celery broker queue.
# TYPE cloudigrade_celery_queue_length gauge
cloudigrade_celery_queue_length{queue_name="delete_cloud_account"} 0.0
cloudigrade_celery_queue_length{queue_name="enable_account"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_inactive_users"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_cloud_accounts_not_in_sources"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_orphaned_cloud_accounts"} 0.0
cloudigrade_celery_queue_length{queue_name="fix_problematic_runs"} 0.0
cloudigrade_celery_queue_length{queue_name="inspect_pending_images"} 12.0
cloudigrade_celery_queue_length{queue_name="migrate_account_numbers_to_org_ids"} 0.0
cloudigrade_celery_queue_length{queue_name="notify_application_availability_task"} 25.0
cloudigrade_celery_queue_length{queue_name="persist_inspection_cluster_results_task"} 213.0
cloudigrade_celery_queue_length{queue_name="recalculate_concurrent_usage_for_all_users"} 2.0
cloudigrade_celery_queue_length{queue_name="recalculate_concurrent_usage_for_user_id"} 0.0
cloudigrade_celery_queue_length{queue_name="recalculate_concurrent_usage_for_user_id_on_date"} 0.0
cloudigrade_celery_queue_length{queue_name="recalculate_runs_for_all_cloud_accounts"} 5.0
cloudigrade_celery_queue_length{queue_name="recalculate_runs_for_cloud_account_id"} 0.0
cloudigrade_celery_queue_length{queue_name="recalculate_runs_for_instance_id"} 0.0
cloudigrade_celery_queue_length{queue_name="check_and_cache_sqs_queues_lengths"} 5.0
cloudigrade_celery_queue_length{queue_name="create_from_sources_kafka_message"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_from_sources_kafka_message"} 0.0
cloudigrade_celery_queue_length{queue_name="update_from_sources_kafka_message"} 0.0
cloudigrade_celery_queue_length{queue_name="pause_from_sources_kafka_message"} 0.0
cloudigrade_celery_queue_length{queue_name="unpause_from_sources_kafka_message"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_user"} 2.0
cloudigrade_celery_queue_length{queue_name="synthesize_cloud_accounts"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_images"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_instances"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_instance_events"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_runs_and_usage"} 0.0
cloudigrade_celery_queue_length{queue_name="synthesize_concurrent_usage"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_expired_synthetic_data"} 0.0
cloudigrade_celery_queue_length{queue_name="analyze_log"} 434.0
cloudigrade_celery_queue_length{queue_name="configure_customer_aws_and_create_cloud_account"} 0.0
cloudigrade_celery_queue_length{queue_name="copy_ami_snapshot"} 0.0
cloudigrade_celery_queue_length{queue_name="copy_ami_to_customer_account"} 0.0
cloudigrade_celery_queue_length{queue_name="delete_snapshot"} 0.0
cloudigrade_celery_queue_length{queue_name="initial_aws_describe_instances"} 0.0
cloudigrade_celery_queue_length{queue_name="launch_inspection_instance"} 0.0
cloudigrade_celery_queue_length{queue_name="remove_snapshot_ownership"} 0.0
cloudigrade_celery_queue_length{queue_name="repopulate_ec2_instance_mapping"} 0.0
cloudigrade_celery_queue_length{queue_name="repopulate_azure_instance_mapping"} 0.0
cloudigrade_celery_queue_length{queue_name="check_azure_subscription_and_create_cloud_account"} 0.0
```