### PR TITLE
enable more redis commands via internal API

### DIFF
--- a/cloudigrade/internal/serializers.py
+++ b/cloudigrade/internal/serializers.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext as _
 from django_celery_beat.models import PeriodicTask
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import BooleanField, CharField, ChoiceField
+from rest_framework.fields import BooleanField, CharField, ChoiceField, ListField
 from rest_framework.serializers import ModelSerializer, Serializer
 
 from api import models
@@ -347,4 +347,6 @@ class InternalRedisRawInputSerializer(Serializer):
     ]
 
     command = ChoiceField(allowed_commands, required=True)
-    args = CharField(required=True, min_length=1)
+    args = ListField(
+        required=True, allow_empty=False, min_length=1, child=CharField(min_length=1)
+    )

--- a/cloudigrade/internal/serializers.py
+++ b/cloudigrade/internal/serializers.py
@@ -329,7 +329,7 @@ class InternalSyntheticDataRequestSerializer(ModelSerializer):
 class InternalRedisRawInputSerializer(Serializer):
     """Serializer to validate input for the internal redis_raw API."""
 
-    allowed_commands = [
+    nondestructive_commands = [
         # generic commands
         "exists",  # determine if a key exists
         "expiretime",  # get the expiration unix timestamp for a key
@@ -345,6 +345,23 @@ class InternalRedisRawInputSerializer(Serializer):
         "sismember",  # determine if a given value is a member of a set
         "smembers",  # list members of the set with the given key
     ]
+
+    destructive_commands = [
+        # generic commands
+        "delete",  # delete a key
+        "expire",  # set a key's time to live in seconds
+        "mset",  # set multiple values to multiple keys
+        "set",  # set the string value of a key
+        # list commands
+        "lmove",  # pop an element from a list, push it to another list, and return it
+        "lmpop",  # pop elements from a list
+        "lpop",  # remove and get the first elements from a list
+        "lpush",  # prepend one or multiple elements to a list
+        "rpop",  # remove and get the last elements from a list
+        "rpush",  # append one or multiple elements to a list
+    ]
+
+    allowed_commands = nondestructive_commands + destructive_commands
 
     command = ChoiceField(allowed_commands, required=True)
     args = ListField(

--- a/cloudigrade/internal/serializers.py
+++ b/cloudigrade/internal/serializers.py
@@ -330,14 +330,20 @@ class InternalRedisRawInputSerializer(Serializer):
     """Serializer to validate input for the internal redis_raw API."""
 
     allowed_commands = [
-        "keys",  # find all keys matching the given pattern
-        "type",  # get the type of a key
+        # generic commands
+        "exists",  # determine if a key exists
+        "expiretime",  # get the expiration unix timestamp for a key
         "get",  # get the value of a key
+        "keys",  # find all keys matching the given pattern
+        "ttl",  # get the time to live for a key in seconds
+        "type",  # get the type of a key
+        # list commands
         "llen",  # get the length of a list
         "lrange",  # get a range of elements from a list
+        # set commands
         "scard",  # get the number of members in a set
-        "smembers",  # list members of the set with the given key
         "sismember",  # determine if a given value is a member of a set
+        "smembers",  # list members of the set with the given key
     ]
 
     command = ChoiceField(allowed_commands, required=True)

--- a/cloudigrade/internal/tests/views/test_redis_raw.py
+++ b/cloudigrade/internal/tests/views/test_redis_raw.py
@@ -36,10 +36,11 @@ class RedisRawViewTest(TestCase):
         command = _faker.random_element(
             InternalRedisRawInputSerializer.allowed_commands
         )
-        individual_args = [_faker.word(), _faker.word()]
-        args_string = " ".join(individual_args)
+        args = [_faker.word(), _faker.word()]
         request = self.factory.post(
-            "/redis_raw/", data={"command": command, "args": args_string}, format="json"
+            "/redis_raw/",
+            data={"command": command, "args": args},
+            format="json",
         )
 
         redis_command_results = _faker.sentence()
@@ -49,14 +50,14 @@ class RedisRawViewTest(TestCase):
         expected_response_data = {"results": redis_command_results}
 
         response = redis_raw(request)
-        mock_func.assert_called_with(*individual_args)
+        mock_func.assert_called_with(*args)
         self.assertEqual(response.status_code, 200)
         self.assertExpectedJsonResponse(response, expected_response_data)
 
     def test_unsupported_command_fails(self):
         """Test failure path for an unsupported command."""
         command = _faker.word()
-        args = _faker.word()
+        args = [_faker.word()]
         request = self.factory.post(
             "/redis_raw/", data={"command": command, "args": args}, format="json"
         )
@@ -76,7 +77,7 @@ class RedisRawViewTest(TestCase):
         command = _faker.random_element(
             InternalRedisRawInputSerializer.allowed_commands
         )
-        args = _faker.word()
+        args = [_faker.word()]
         request = self.factory.post(
             "/redis_raw/", data={"command": command, "args": args}, format="json"
         )
@@ -96,7 +97,7 @@ class RedisRawViewTest(TestCase):
         command = _faker.random_element(
             InternalRedisRawInputSerializer.allowed_commands
         )
-        args = _faker.word()
+        args = [_faker.word()]
         request = self.factory.post(
             "/redis_raw/", data={"command": command, "args": args}, format="json"
         )

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -421,7 +421,7 @@ def redis_raw(request):
     serializer = serializers.InternalRedisRawInputSerializer(data=request.data)
     if serializer.is_valid(raise_exception=True):
         command = serializer.validated_data["command"]
-        args = serializer.validated_data["args"].split(" ")
+        args = serializer.validated_data["args"]
 
         try:
             results = redis.execute_command(command, args)

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -423,6 +423,15 @@ def redis_raw(request):
         command = serializer.validated_data["command"]
         args = serializer.validated_data["args"]
 
+        if command in serializer.destructive_commands:
+            logger.warning(
+                _(
+                    "potentially destructive redis command via internal api: "
+                    "%(command)s"
+                ),
+                {"command": command},
+            )
+
         try:
             results = redis.execute_command(command, args)
         except TypeError as e:


### PR DESCRIPTION
This change adds several potentially destructive commands. We can now create, delete, and change some values.

With great power… 🕷️

This change also alters the API input syntax. Instead of taking `args` as a single string, it now expects a list of strings. So, we can now provide arguments that _contain_ spaces.

Examples:

```
❯ http -b localhost:8080/internal/redis_raw/ command="keys" args:='["brasmith-local-re*"]'
{
    "results": [
        "brasmith-local-recalculate_runs_for_all_cloud_accounts",
        "brasmith-local-recalculate_concurrent_usage_for_all_users"
    ]
}
```

```
http -b localhost:8080/internal/redis_raw/ command="rpush" args:='["mylist", "first item", "second fiddle", "third potato"]'
{
    "results": 3
}

❯ http -b localhost:8080/internal/redis_raw/ command="lrange" args:='["mylist", "0", "-1"]'
{
    "results": [
        "first item",
        "second fiddle",
        "third potato"
    ]
}

❯ http -b localhost:8080/internal/redis_raw/ command="lpush" args:='["mylist", "before first item"]'
{
    "results": 4
}

❯ http -b localhost:8080/internal/redis_raw/ command="lrange" args:='["mylist", "0", "-1"]'
{
    "results": [
        "before first item",
        "first item",
        "second fiddle",
        "third potato"
    ]
}

❯ http -b localhost:8080/internal/redis_raw/ command="delete" args:='["mylist"]'
{
    "results": 1
}

❯ http -b localhost:8080/internal/redis_raw/ command="get" args:='["mylist"]'
{
    "results": null
}

❯ http -b localhost:8080/internal/redis_raw/ command="type" args:='["mylist"]'
{
    "results": "none"
}
```