### PR TITLE
make cache_memoize calls use locmem

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -588,7 +588,10 @@ CACHES = {
         "LOCATION": REDIS_URL,
         "KEY_PREFIX": f"{CLOUDIGRADE_ENVIRONMENT}-cloudigrade",
         "TIMEOUT": CACHE_TTL_DEFAULT,
-    }
+    },
+    "locmem": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
 }
 
 # How far back should we look for related data when recalculating runs

--- a/cloudigrade/config/settings/test.py
+++ b/cloudigrade/config/settings/test.py
@@ -24,5 +24,8 @@ ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API = True
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    }
+    },
+    "locmem": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
 }

--- a/cloudigrade/util/aws/sqs.py
+++ b/cloudigrade/util/aws/sqs.py
@@ -181,7 +181,7 @@ def extract_sqs_message(message, service="s3"):
     return extracted_records
 
 
-@cache_memoize(settings.CACHE_TTL_DEFAULT)
+@cache_memoize(settings.CACHE_TTL_DEFAULT, cache_alias="locmem")
 def get_sqs_queue_url(queue_name, region=settings.SQS_DEFAULT_REGION):
     """
     Get the SQS queue URL for the given queue name.

--- a/cloudigrade/util/redhatcloud/sources.py
+++ b/cloudigrade/util/redhatcloud/sources.py
@@ -229,7 +229,7 @@ def get_sources_account_number_from_headers(headers):
     return None
 
 
-@cache_memoize(settings.CACHE_TTL_SOURCES_APPLICATION_TYPE_ID)
+@cache_memoize(settings.CACHE_TTL_SOURCES_APPLICATION_TYPE_ID, cache_alias="locmem")
 def get_cloudigrade_application_type_id(account_number, org_id):
     """Get the cloudigrade application type id from sources."""
     url = (


### PR DESCRIPTION
This really shouldn't be necessary, but we're having redis issues and performance issues, and I'm wondering if they're related, and maybe using redis less will help.

feelsbadman.jpg