### PR TITLE
celery worker `--without-gossip --without-mingle`

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -920,6 +920,8 @@ objects:
             worker
             --loglevel info
             --pool solo
+            --without-gossip
+            --without-mingle
             --concurrency 1
             --task-events
             --queues ${CELERY_QUEUE_NAMES}

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1920,11 +1920,11 @@ parameters:
 - name: WATCHTOWER_SEND_INTERVAL
   displayName: Watchtower send interval (seconds)
   required: true
-  value: '0.0'
+  value: '1.0'
 - name: WATCHTOWER_USE_QUEUES
   displayName: Watchtower use queues
   required: true
-  value: 'false'
+  value: 'true'
 - name: DELETE_ORPHANED_ACCOUNTS_UPDATED_MORE_THAN_SECONDS_AGO
   displayName: Delete orphaned accounts updated more than seconds ago
   required: true


### PR DESCRIPTION
Run celery worker with `--without-gossip --without-mingle` because `--pool solo` fails to communicate heartbeats correctly and is spamming logs with *tens of thousands* of messages like:

```
2022-08-01 20:38:15,053 | INFO | 1 | gossip.py:on_node_lost:145 | requestid:None | missed heartbeat from celery@cloudigrade-worker-6cb74b745f-s7d2k
2022-08-01 20:38:45,169 | INFO | 1 | gossip.py:on_node_lost:145 | requestid:None | missed heartbeat from celery@cloudigrade-worker-6cb74b745f-lcnrt
2022-08-01 20:39:15,352 | INFO | 1 | gossip.py:on_node_lost:145 | requestid:None | missed heartbeat from celery@cloudigrade-worker-6cb74b745f-d9v84
```

Unfortunately, the official Celery docs do not do good job describing these options. So, see these Stack Overflow posts for relevant explanations:
- [celery missed heartbeat (on_node_lost)](https://stackoverflow.com/questions/21132240/celery-missed-heartbeat-on-node-lost)
- [What are the consequences of disabling gossip, mingle and heartbeat for celery workers?](https://stackoverflow.com/questions/55249197/what-are-the-consequences-of-disabling-gossip-mingle-and-heartbeat-for-celery-w)
- [Application impacts of celery workers running with the `--without-heartbeat` flag](https://stackoverflow.com/questions/66978028/application-impacts-of-celery-workers-running-with-the-without-heartbeat-fla)

I'm also updating default values WATCHTOWER_SEND_INTERVAL=1.0 and WATCHTOWER_USE_QUEUES=true for all deployments.