### PR TITLE
identity header is_org_admin is no longer required to access any APIs

### DIFF
--- a/cloudigrade/api/tests/test_authenticate.py
+++ b/cloudigrade/api/tests/test_authenticate.py
@@ -205,14 +205,17 @@ class IdentityHeaderAuthenticateTestCase(TestCase):
                 self.assertEqual(self.account_number, user.account_number)
                 self.assertIn("Decoded identity header: ", logging_watcher.output[1])
 
-    def test_authenticate_not_org_admin_fails(self):
-        """Test that header without org admin user fails."""
+    def test_authenticate_not_org_admin_succeeds(self):
+        """Test that header without org admin user succeeds."""
         request = Mock()
         request.META = {settings.INSIGHTS_IDENTITY_HEADER: self.rh_header_not_admin}
 
-        with self.assertRaises(exceptions.PermissionDenied) as e:
-            self.auth_class.authenticate(request)
-        self.assertIn("User must be an org admin", e.exception.args[0])
+        user, auth = self.auth_class.authenticate(request)
+
+        self.assertTrue(auth)
+        self.assertEqual(self.account_number, user.account_number)
+        self.assertEqual(self.org_id, user.org_id)
+        self.assertEqual(user, self.user)
 
     def test_authenticate_bad_b64_padding(self):
         """Test authentication fails when the identity header has bad b64 padding."""

--- a/cloudigrade/internal/authentication.py
+++ b/cloudigrade/internal/authentication.py
@@ -7,16 +7,16 @@ class IdentityHeaderAuthenticationInternal(IdentityHeaderAuthentication):
     Authentication class that only optionally uses the identity header.
 
     This authentication checks for the identity header but does not require the identity
-    to exist or to have org_admin enabled. If we cannot find a User matching the header
-    identity, then authentication fails and returns None. We expect the downstream view
-    to determine if access should be allowed if no authentication exists.
+    to exist. If we cannot find a User matching the header identity, then authentication
+    fails and gracefully returns None. We expect the downstream view to determine if
+    access should be allowed if no authentication exists.
 
     This "optional" variant exists because internal Red Hat console services do not
     consistently set the identity header, and we want to grant generally broad access
     to some of our internal APIs.
     """
 
-    require_account_number = False
+    require_account_number_or_org_id = False
     require_user = False
     create_user = False
 
@@ -29,7 +29,7 @@ class IdentityHeaderAuthenticationInternalCreateUser(IdentityHeaderAuthenticatio
     header, but if a matching User is not found, then we create a new User.
     """
 
-    require_account_number = True
+    require_account_number_or_org_id = True
     require_user = False
     create_user = True
 
@@ -46,7 +46,7 @@ class IdentityHeaderAuthenticationInternalAllowFakeIdentityHeader(
     normal INSIGHTS_IDENTITY_HEADER header which we cannot override.
     """
 
-    require_account_number = True
+    require_account_number_or_org_id = True
     require_user = True
     create_user = False
     allow_internal_fake_identity_header = True

--- a/cloudigrade/internal/authentication.py
+++ b/cloudigrade/internal/authentication.py
@@ -11,12 +11,11 @@ class IdentityHeaderAuthenticationInternal(IdentityHeaderAuthentication):
     identity, then authentication fails and returns None. We expect the downstream view
     to determine if access should be allowed if no authentication exists.
 
-    This "optional" variant exists because internal Red Hat Cloud services do not
-    consistently set the org_admin value, and we want to grant generally broad access to
-    our internal APIs.
+    This "optional" variant exists because internal Red Hat console services do not
+    consistently set the identity header, and we want to grant generally broad access
+    to some of our internal APIs.
     """
 
-    require_org_admin = False
     require_account_number = False
     require_user = False
     create_user = False
@@ -24,14 +23,12 @@ class IdentityHeaderAuthenticationInternal(IdentityHeaderAuthentication):
 
 class IdentityHeaderAuthenticationInternalCreateUser(IdentityHeaderAuthentication):
     """
-    Authentication class that uses identity header to creates Users.
+    Authentication class that uses identity header to create Users.
 
-    This authentication checks for the identity header but does not require the identity
-    to have org_admin enabled. If we cannot find a User matching the header's identity,
-    then we create a new User from the identity header's account number.
+    This authentication checks for a User matching the attributes in the identity
+    header, but if a matching User is not found, then we create a new User.
     """
 
-    require_org_admin = False
     require_account_number = True
     require_user = False
     create_user = True
@@ -41,13 +38,14 @@ class IdentityHeaderAuthenticationInternalAllowFakeIdentityHeader(
     IdentityHeaderAuthentication
 ):
     """
-    Authentication class that uses identity header to query/trigger concurrent reports.
+    Authentication class that uses an alternate HTTP header for the identity definition.
 
-    This authentication checks for the identity header and requires the identity
-    to have org_admin enabled.
+    This authentication checks the custom INSIGHTS_INTERNAL_FAKE_IDENTITY_HEADER header
+    before checking the normal INSIGHTS_IDENTITY_HEADER header. This enables us to make
+    internal requests simulating other users because the 3scale gateway populates the
+    normal INSIGHTS_IDENTITY_HEADER header which we cannot override.
     """
 
-    require_org_admin = True
     require_account_number = True
     require_user = True
     create_user = False

--- a/cloudigrade/internal/tests/test_authenticate.py
+++ b/cloudigrade/internal/tests/test_authenticate.py
@@ -155,7 +155,7 @@ class IdentityHeaderAuthenticationInternalConcurrentCase(TestCase):
         )
 
     def test_authenticate_with_valid_account_number_and_not_org_admin_fake_header(self):
-        """Test authentication with valid account_number and without org admin fails."""
+        """Test authentication with valid account_number but no org admin succeeds."""
         request = Mock()
         fake_header = util_helper.get_identity_auth_header(
             account_number=self.account_number,
@@ -165,9 +165,11 @@ class IdentityHeaderAuthenticationInternalConcurrentCase(TestCase):
             settings.INSIGHTS_IDENTITY_HEADER: self.internal_rh_header,
             settings.INSIGHTS_INTERNAL_FAKE_IDENTITY_HEADER: fake_header,
         }
-        with self.assertRaises(exceptions.PermissionDenied) as e:
-            self.auth_class.authenticate(request)
-        self.assertIn("User must be an org admin.", str(e.exception))
+
+        user, auth = self.auth_class.authenticate(request)
+
+        self.assertTrue(auth)
+        self.assertEqual(self.account_number, user.account_number)
 
     def test_authenticate_with_invalid_account_number_and_org_admin_fake_header(self):
         """Test authentication with invalid account_number and org admin fails."""
@@ -197,9 +199,8 @@ class IdentityHeaderAuthenticationInternalConcurrentCase(TestCase):
             settings.INSIGHTS_IDENTITY_HEADER: self.internal_rh_header,
             settings.INSIGHTS_INTERNAL_FAKE_IDENTITY_HEADER: fake_header,
         }
-        with self.assertRaises(exceptions.PermissionDenied) as e:
+        with self.assertRaises(exceptions.AuthenticationFailed):
             self.auth_class.authenticate(request)
-        self.assertIn("User must be an org admin.", str(e.exception))
 
     def test_authenticate_with_valid_account_number_and_org_admin_headers(self):
         """Test authentication with valid account_number and org admin succeeds."""

--- a/cloudigrade/internal/tests/test_authenticate.py
+++ b/cloudigrade/internal/tests/test_authenticate.py
@@ -149,8 +149,8 @@ class IdentityHeaderAuthenticationInternalConcurrentCase(TestCase):
         with self.assertRaises(exceptions.AuthenticationFailed) as e:
             self.auth_class.authenticate(request)
         self.assertIn(
-            "identity account number is required but account_number"
-            " or org_id was not present in request.",
+            "identity account number or org id is required, but neither"
+            " is present in request.",
             str(e.exception),
         )
 

--- a/cloudigrade/internal/tests/viewsets/test_dailyconcurrentusageviewset.py
+++ b/cloudigrade/internal/tests/viewsets/test_dailyconcurrentusageviewset.py
@@ -86,6 +86,7 @@ class InternalDailyConcurrentUsageViewSetTest(SharedDailyConcurrentUsageViewSetT
         )
         response = client.get(self.concurrent_api_url, data={}, format="json")
         body = response.json()
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(body["meta"]["count"], 1)
         self.assertEqual(len(body["data"]), 1)
         self.assertEqual(body["data"][0]["date"], str(yesterday))
@@ -120,7 +121,7 @@ class InternalDailyConcurrentUsageViewSetTest(SharedDailyConcurrentUsageViewSetT
         Test with a False is_org_admin parameter.
 
         Test with an internal account header, a valid account_number and False
-        org_admin headers, expect an authentication error.
+        org_admin headers, and expect success because org_admin is not required.
         """
         yesterday = get_today() - datetime.timedelta(days=1)
         today = get_today()
@@ -137,5 +138,7 @@ class InternalDailyConcurrentUsageViewSetTest(SharedDailyConcurrentUsageViewSetT
         )
         response = client.get(self.concurrent_api_url, data={}, format="json")
         body = response.json()
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(body["detail"], "User must be an org admin.")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["meta"]["count"], 1)
+        self.assertEqual(len(body["data"]), 1)
+        self.assertEqual(body["data"][0]["date"], str(yesterday))

--- a/docs/rest-api-examples.py
+++ b/docs/rest-api-examples.py
@@ -73,6 +73,7 @@ class DocsApiHandler(object):
         api_helper.generate_instance_type_definitions(cloud_type="azure")
 
         self.customer_account_number = "100001"
+        self.customer_org_id = "200002"
         self.customer_user = util_helper.get_test_user(
             self.customer_account_number, is_superuser=False
         )
@@ -80,7 +81,9 @@ class DocsApiHandler(object):
         self.customer_user.save()
 
         self.x_rh_identity = util_helper.get_identity_auth_header(
-            self.customer_account_number
+            self.customer_account_number,
+            is_org_admin=False,
+            org_id=self.customer_org_id,
         ).decode("utf-8")
 
         # Create the fake HTTP clients

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -36,15 +36,13 @@ The ``X-RH-IDENTITY`` header's value must contain the base64-encoded JSON data l
     {
         "identity": {
             "account_number": "100001",
-            "user": {
-                "is_org_admin": true
-            }
+            "org_id": "200002"
         }
     }
 
 .. code:: bash
 
-    HTTP_X_RH_IDENTITY=eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDAxIiwgInVzZXIiOiB7ImlzX29yZ19hZG1pbiI6IHRydWV9fX0=
+    HTTP_X_RH_IDENTITY=eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTAwMDAxIiwgIm9yZ19pZCI6ICIyMDAwMDIifX0=
 
 Some internal APIs may instead accept a combination of these custom HTTP headers:
 
@@ -2536,7 +2534,7 @@ Request:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 390
+    Content-Length: 394
     Content-Type: application/json
     Referrer-Policy: same-origin
     X-CLOUDIGRADE-REQUEST-ID: f653b840-145a-421f-9bb1-0758592d02d4
@@ -2549,7 +2547,7 @@ Request:
                 "account_number": "100001",
                 "date_joined": "2019-01-01T00:00:00Z",
                 "id": 1,
-                "org_id": null,
+                "org_id": "200002",
                 "username": "100001",
                 "uuid": "d862c2e3-6b0a-42f7-827c-67ebc8d44df7"
             }


### PR DESCRIPTION
Also clean up some docstrings and rename require_account_number to require_account_number_or_org_id to be more accurate.

For https://github.com/cloudigrade/cloudigrade/issues/1287