### PR TITLE
Fixed the examples in docs/rest-api-examples.rst

### DIFF
--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -67,12 +67,12 @@ Overview
 
 The following resource paths are currently available:
 
--  ``/api/v2/accounts/`` returns accounts data
--  ``/api/v2/instances/`` returns instances data
--  ``/api/v2/images/`` returns images data
--  ``/api/v2/sysconfig/`` returns sysconfig data
--  ``/api/v2/azure-offer-template/`` returns azure offer template data
--  ``/api/v2/concurrent/`` returns concurrency data
+-  ``/api/cloudigrade/v2/accounts/`` returns accounts data
+-  ``/api/cloudigrade/v2/instances/`` returns instances data
+-  ``/api/cloudigrade/v2/images/`` returns images data
+-  ``/api/cloudigrade/v2/sysconfig/`` returns sysconfig data
+-  ``/api/cloudigrade/v2/azure-offer-template/`` returns azure offer template data
+-  ``/api/cloudigrade/v2/concurrent/`` returns concurrency data
 
 
 User Setup

--- a/docs/rest-api-examples.rst.jinja
+++ b/docs/rest-api-examples.rst.jinja
@@ -58,12 +58,12 @@ Overview
 
 The following resource paths are currently available:
 
--  ``/api/v2/accounts/`` returns accounts data
--  ``/api/v2/instances/`` returns instances data
--  ``/api/v2/images/`` returns images data
--  ``/api/v2/sysconfig/`` returns sysconfig data
--  ``/api/v2/azure-offer-template/`` returns azure offer template data
--  ``/api/v2/concurrent/`` returns concurrency data
+-  ``/api/cloudigrade/v2/accounts/`` returns accounts data
+-  ``/api/cloudigrade/v2/instances/`` returns instances data
+-  ``/api/cloudigrade/v2/images/`` returns images data
+-  ``/api/cloudigrade/v2/sysconfig/`` returns sysconfig data
+-  ``/api/cloudigrade/v2/azure-offer-template/`` returns azure offer template data
+-  ``/api/cloudigrade/v2/concurrent/`` returns concurrency data
 
 
 User Setup


### PR DESCRIPTION
- Fixed the examples for docs/rest-api-examples.rst where we had the older /api/v2/\<entity\> urls that did not include the service name. should be /api/cloudigrade/v2/\<entity\>.