### PR TITLE
add optional `TEST_VERBOSITY` to adjust Django test verbosity in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ setenv =
   AWS_SECRET_ACCESS_KEY=bar
   CLOUDIGRADE_ENVIRONMENT=tox-test
 commands =
-  coverage run {toxinidir}/cloudigrade/manage.py test --timing {posargs: api internal util} --parallel
+  coverage run {toxinidir}/cloudigrade/manage.py test -v{env:TEST_VERBOSITY:1} --timing {posargs: api internal util} --parallel
   coverage combine
   coverage report --show-missing
   coverage xml -o artifacts/junit-cloudigrade.xml


### PR DESCRIPTION
I thought about this last week when trying to debug unrelated test issues in GitHub. Maybe if we like this, we can change the GitHub action's definition to use `TEST_VERBOSITY=2` to make them slightly noisier by default while keeping tox relatively quiet for local runs.

Demo recording locally calling `tox -e py39` to show existing behavior is preserved and then `TEST_VERBOSITY=3 tox -e py39` to show noisy output:

[![asciicast](https://asciinema.org/a/513529.svg)](https://asciinema.org/a/513529)