### PR TITLE
replace old "clount" nickname with "cloud account"

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -1080,15 +1080,16 @@ def update_aws_cloud_account(
     if cloud_account.content_object.aws_account_id != customer_aws_account_id:
         logger.info(
             _(
-                "Cloud Account with ID %(clount_id)s and aws_account_id "
+                "Cloud Account with ID %(cloud_account_id)s and aws_account_id "
                 "%(old_aws_account_id)s has received an update request for ARN "
                 "%(new_arn)s and aws_account_id %(new_aws_account_id)s. "
                 "Since the aws_account_id is different, Cloud Account ID "
-                "%(clount_id)s will be deleted. A new Cloud Account will be created "
-                "with aws_account_id %(new_aws_account_id)s and arn %(new_arn)s."
+                "%(cloud_account_id)s will be deleted. A new Cloud Account will be "
+                "created with aws_account_id %(new_aws_account_id)s and arn "
+                "%(new_arn)s."
             ),
             {
-                "clount_id": cloud_account.id,
+                "cloud_account_id": cloud_account.id,
                 "old_aws_account_id": cloud_account.content_object.aws_account_id,
                 "new_aws_account_id": customer_aws_account_id,
                 "new_arn": customer_arn,
@@ -1100,7 +1101,7 @@ def update_aws_cloud_account(
         # we already have explicit calls to notify if we can't create the CloudAccount.
         cloud_account.disable(power_off_instances=False, notify_sources=False)
 
-        # Remove instances associated with the clount
+        # Remove instances associated with the cloud account
         # TODO instead of deleting instances here, delete the original CloudAccount.
         # We can't delete it here due to 7b02f90fc643533246e51f20078e8ae2366df32b, but
         # we could delete it after we've created the new CloudAccount a few lines later.

--- a/cloudigrade/api/migrations/0020_verify_aws_access.py
+++ b/cloudigrade/api/migrations/0020_verify_aws_access.py
@@ -10,23 +10,23 @@ def create_verify_tasks(apps, schema_editor):
     IntervalSchedule = apps.get_model("django_celery_beat", "IntervalSchedule")
     PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
 
-    aws_clounts = AwsCloudAccount.objects.filter(verify_task_id__isnull=True)
+    aws_cloud_accounts = AwsCloudAccount.objects.filter(verify_task_id__isnull=True)
 
-    for aws_clount in aws_clounts:
+    for aws_cloud_account in aws_cloud_accounts:
         schedule, _ = IntervalSchedule.objects.get_or_create(every=1, period="days")
         verify_task = PeriodicTask.objects.create(
             interval=schedule,
-            name=f"Verify {aws_clount.account_arn}.",
-            start_time=aws_clount.created_at,
+            name=f"Verify {aws_cloud_account.account_arn}.",
+            start_time=aws_cloud_account.created_at,
             task="api.clouds.aws.tasks.verify_account_permissions",
             kwargs=json.dumps(
                 {
-                    "account_arn": aws_clount.account_arn,
+                    "account_arn": aws_cloud_account.account_arn,
                 }
             ),
         )
-        aws_clount.verify_task = verify_task
-        aws_clount.save()
+        aws_cloud_account.verify_task = verify_task
+        aws_cloud_account.save()
 
 
 class Migration(migrations.Migration):

--- a/cloudigrade/api/models.py
+++ b/cloudigrade/api/models.py
@@ -136,7 +136,7 @@ class CloudAccount(BaseGenericModel):
     enabled_at = models.DateTimeField(null=True, blank=True)
 
     # We must store the platform authentication_id in order to know things
-    # like when to delete the Clount.
+    # like when to delete the CloudAccount.
     # Unfortunately because of the way platform Sources is designed
     # we must also keep track of the source_id and application_id.
     # Why? see https://github.com/RedHatInsights/sources-api/issues/179
@@ -402,7 +402,7 @@ def cloud_account_post_delete_callback(*args, **kwargs):
     """
     instance = kwargs["instance"]
 
-    # When multiple clounts are deleted at the same time django will
+    # When multiple cloud accounts are deleted at the same time django will
     # attempt to delete the user multiple times.
     # Catch and log the raised DoesNotExist error from the additional
     # attempts.
@@ -418,7 +418,9 @@ def cloud_account_post_delete_callback(*args, **kwargs):
             )
             instance.user.delete()
     except User.DoesNotExist:
-        logger.info(_("User for clount id %s has already been deleted."), instance.id)
+        logger.info(
+            _("User for cloud account id %s has already been deleted."), instance.id
+        )
 
 
 class MachineImage(BaseGenericModel):

--- a/cloudigrade/api/serializers.py
+++ b/cloudigrade/api/serializers.py
@@ -161,8 +161,8 @@ class CloudAccountSerializer(ModelSerializer):
         """
         Create an AWS flavored CloudAccount.
 
-        Validate that we have the right access to the customer's AWS clount,
-        set up Cloud Trail on their clount.
+        Validate that we have the right access to the customer's AWS cloud account,
+        set up Cloud Trail on their cloud account.
 
         """
         arn = validated_data["account_arn"]

--- a/cloudigrade/api/tasks/sources.py
+++ b/cloudigrade/api/tasks/sources.py
@@ -268,7 +268,9 @@ def update_from_sources_kafka_message(message, headers):
         return
 
     try:
-        clount = CloudAccount.objects.get(platform_authentication_id=authentication_id)
+        cloud_account = CloudAccount.objects.get(
+            platform_authentication_id=authentication_id
+        )
 
         authentication = sources.get_authentication(
             account_number, org_id, authentication_id
@@ -324,7 +326,7 @@ def update_from_sources_kafka_message(message, headers):
         # the sources API call
         if authentication.get("authtype") == settings.SOURCES_CLOUDMETER_ARN_AUTHTYPE:
             update_aws_cloud_account(
-                clount,
+                cloud_account,
                 arn,
                 account_number,
                 org_id,

--- a/cloudigrade/api/tests/clouds/aws/util/test_create_aws_cloud_account.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_create_aws_cloud_account.py
@@ -12,7 +12,7 @@ from util.tests import helper as util_helper
 _faker = faker.Faker()
 
 
-class CreateAWSClountTest(TestCase):
+class CreateAWSCloudAccountTest(TestCase):
     """Test cases for api.cloud.aws.util.create_aws_cloud_account."""
 
     def setUp(self):
@@ -25,7 +25,7 @@ class CreateAWSClountTest(TestCase):
         self.source_id = _faker.pyint()
 
     @patch.object(CloudAccount, "enable")
-    def test_create_aws_clount_success(self, mock_enable):
+    def test_create_aws_cloud_account_success(self, mock_enable):
         """Test create_aws_cloud_account success."""
         util.create_aws_cloud_account(
             self.user, self.arn, self.auth_id, self.app_id, self.source_id
@@ -35,7 +35,7 @@ class CreateAWSClountTest(TestCase):
 
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "enable")
-    def test_create_aws_clount_fails_same_aws_account_different_arn(
+    def test_create_aws_cloud_account_fails_same_aws_account_different_arn(
         self, mock_enable, mock_notify_sources
     ):
         """
@@ -70,7 +70,7 @@ class CreateAWSClountTest(TestCase):
 
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "enable")
-    def test_create_aws_clount_fails_with_same_arn_different_user(
+    def test_create_aws_cloud_account_fails_with_same_arn_different_user(
         self, mock_enable, mock_notify_sources
     ):
         """Test create_aws_cloud_account fails with same ARN and a different user."""
@@ -97,7 +97,7 @@ class CreateAWSClountTest(TestCase):
 
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "enable")
-    def test_create_aws_clount_fails_with_same_arn_same_user(
+    def test_create_aws_cloud_account_fails_with_same_arn_same_user(
         self, mock_enable, mock_notify_sources
     ):
         """Test create_aws_cloud_account failure message for same user."""
@@ -122,7 +122,7 @@ class CreateAWSClountTest(TestCase):
 
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "enable")
-    def test_create_aws_clount_fails_with_different_user_same_account_id(
+    def test_create_aws_cloud_account_fails_with_different_user_same_account_id(
         self, mock_enable, mock_notify_sources
     ):
         """Test create_aws_cloud_account failure message for different user."""

--- a/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
+++ b/cloudigrade/api/tests/clouds/aws/util/test_update_aws_cloud_account.py
@@ -14,7 +14,7 @@ from util.tests import helper as util_helper
 _faker = faker.Faker()
 
 
-class UpdateAWSClountTest(TestCase):
+class UpdateAWSCloudAccountTest(TestCase):
     """Test cases for api.cloud.aws.util.update_aws_cloud_account."""
 
     def setUp(self):
@@ -28,7 +28,7 @@ class UpdateAWSClountTest(TestCase):
         self.app_id = _faker.pyint()
         self.source_id = _faker.pyint()
 
-        self.clount = api_helper.generate_cloud_account(
+        self.cloud_account = api_helper.generate_cloud_account(
             arn=self.arn,
             aws_account_id=self.aws_account_id,
             user=self.user,
@@ -38,10 +38,12 @@ class UpdateAWSClountTest(TestCase):
         )
 
     @patch("api.tasks.sources.notify_application_availability_task")
-    def test_update_aws_clount_notifies_sources_invalid_arn(self, mock_notify_sources):
+    def test_update_aws_cloud_account_notifies_sources_invalid_arn(
+        self, mock_notify_sources
+    ):
         """Test update_aws_cloud_account notifies sources if ARN is invalid."""
         util.update_aws_cloud_account(
-            self.clount,
+            self.cloud_account,
             "INVALID",
             self.account_number,
             self.org_id,
@@ -52,17 +54,17 @@ class UpdateAWSClountTest(TestCase):
 
     @patch.object(CloudAccount, "disable")
     @patch.object(CloudAccount, "enable")
-    def test_update_aws_clount_different_aws_account_id_success(
+    def test_update_aws_cloud_account_different_aws_account_id_success(
         self, mock_enable, mock_disable
     ):
         """Test update_aws_cloud_account works."""
         aws_account_id2 = util_helper.generate_dummy_aws_account_id()
         arn2 = util_helper.generate_dummy_arn(account_id=aws_account_id2)
 
-        api_helper.generate_instance(self.clount)
+        api_helper.generate_instance(self.cloud_account)
 
         util.update_aws_cloud_account(
-            self.clount,
+            self.cloud_account,
             arn2,
             self.account_number,
             self.org_id,
@@ -78,7 +80,7 @@ class UpdateAWSClountTest(TestCase):
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "disable")
     @patch.object(CloudAccount, "enable")
-    def test_update_aws_clount_different_aws_account_id_fails_arn_already_exists(
+    def test_update_aws_cloud_account_different_aws_account_id_fails_arn_already_exists(
         self, mock_enable, mock_disable, mock_notify_error
     ):
         """Test update_aws_cloud_account fails for duplicate arn."""
@@ -88,7 +90,7 @@ class UpdateAWSClountTest(TestCase):
         api_helper.generate_cloud_account(arn=arn2, aws_account_id=aws_account_id2)
 
         util.update_aws_cloud_account(
-            self.clount,
+            self.cloud_account,
             arn2,
             self.account_number,
             self.org_id,
@@ -104,7 +106,7 @@ class UpdateAWSClountTest(TestCase):
     @patch("api.tasks.sources.notify_application_availability_task")
     @patch.object(CloudAccount, "disable")
     @patch.object(CloudAccount, "enable")
-    def test_update_aws_clount_different_aws_account_id_fails_account_id_already_exists(
+    def test_update_aws_cloud_account_different_aws_account_id_fails_account_id_exists(
         self, mock_enable, mock_disable, mock_notify_error
     ):
         """Test update_aws_cloud_account fails for duplicate aws_account_id."""
@@ -115,7 +117,7 @@ class UpdateAWSClountTest(TestCase):
         api_helper.generate_cloud_account(arn=arn2, aws_account_id=aws_account_id2)
 
         util.update_aws_cloud_account(
-            self.clount,
+            self.cloud_account,
             arn3,
             self.account_number,
             self.org_id,

--- a/cloudigrade/api/tests/tasks/sources/test_delete_from_sources_kafka_message.py
+++ b/cloudigrade/api/tests/tasks/sources/test_delete_from_sources_kafka_message.py
@@ -106,8 +106,8 @@ class DeleteFromSourcesKafkaMessageTest(TestCase):
         # Delete should not have been called.
         self.assertEqual(CloudAccount.objects.count(), 1)
 
-    def test_delete_from_sources_kafka_message_fail_no_clount(self):
-        """Assert delete fails from nonexistent clount."""
+    def test_delete_from_sources_kafka_message_fail_no_cloud_account(self):
+        """Assert delete fails from nonexistent cloud account."""
         self.assertEqual(CloudAccount.objects.count(), 1)
 
         account_number = str(self.user.account_number)

--- a/cloudigrade/api/tests/tasks/sources/test_update_from_sources_kafka_message.py
+++ b/cloudigrade/api/tests/tasks/sources/test_update_from_sources_kafka_message.py
@@ -25,7 +25,7 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
         self.account_id = util_helper.generate_dummy_aws_account_id()
         self.arn = util_helper.generate_dummy_arn(account_id=self.account_id)
 
-        self.clount = api_helper.generate_cloud_account(
+        self.cloud_account = api_helper.generate_cloud_account(
             arn=self.arn, platform_authentication_id=self.authentication_id
         )
 
@@ -64,7 +64,7 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
         sources.update_from_sources_kafka_message(message, headers)
 
         mock_update_account.assert_called_with(
-            self.clount,
+            self.cloud_account,
             self.arn,
             self.account_number,
             self.org_id,
@@ -78,7 +78,7 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
     def test_update_from_sources_kafka_message_updates_arn(
         self, mock_get_auth, mock_notify_sources, mock_get_app
     ):
-        """Assert update_from_sources_kafka_message updates the arn on the clount."""
+        """Assert update_from_sources_kafka_message updates the arn on the account."""
         message, headers = util_helper.generate_authentication_create_message_value(
             self.account_number, self.username, self.authentication_id
         )
@@ -92,9 +92,9 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
             sources.update_from_sources_kafka_message(message, headers)
             mock_verify_permissions.assert_called()
 
-        self.clount.refresh_from_db()
-        self.assertEqual(self.clount.content_object.account_arn, new_arn)
-        self.assertTrue(self.clount.is_enabled)
+        self.cloud_account.refresh_from_db()
+        self.assertEqual(self.cloud_account.content_object.account_arn, new_arn)
+        self.assertTrue(self.cloud_account.is_enabled)
         mock_notify_sources.delay.assert_called()
 
     @patch("util.redhatcloud.sources.get_application")
@@ -104,7 +104,7 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
         self, mock_get_auth, mock_notify_sources, mock_get_app
     ):
         """
-        Assert update_from_sources_kafka_message updates the arn and disables clount.
+        Assert update_from_sources_kafka_message updates the arn and disables account.
 
         This can happen if we get a well-formed ARN, but the AWS-side verification fails
         due to something like badly configured IAM Role or Policy. In this case, we do
@@ -126,14 +126,14 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
             sources.update_from_sources_kafka_message(message, headers)
             mock_verify_permissions.assert_called()
 
-        self.clount.refresh_from_db()
-        self.assertEqual(self.clount.content_object.account_arn, new_arn)
-        self.assertFalse(self.clount.is_enabled)
+        self.cloud_account.refresh_from_db()
+        self.assertEqual(self.cloud_account.content_object.account_arn, new_arn)
+        self.assertFalse(self.cloud_account.is_enabled)
 
         mock_notify_sources.delay.assert_called_once_with(
-            self.clount.user.account_number,
-            self.clount.user.org_id,
-            self.clount.platform_application_id,
+            self.cloud_account.user.account_number,
+            self.cloud_account.user.org_id,
+            self.cloud_account.platform_application_id,
             "unavailable",
             str(validation_error),
         )
@@ -315,9 +315,9 @@ class UpdateFromSourcesKafkaMessageTest(TestCase):
             sources.update_from_sources_kafka_message(message, headers)
             mock_verify_permissions.assert_called()
 
-        self.clount.refresh_from_db()
-        self.assertEqual(self.clount.content_object.account_arn, new_arn)
-        self.assertTrue(self.clount.is_enabled)
+        self.cloud_account.refresh_from_db()
+        self.assertEqual(self.cloud_account.content_object.account_arn, new_arn)
+        self.assertTrue(self.cloud_account.is_enabled)
         mock_notify_sources.delay.assert_called()
 
     @patch("api.tasks.sources.notify_application_availability_task")

--- a/cloudigrade/api/tests/test_models.py
+++ b/cloudigrade/api/tests/test_models.py
@@ -121,8 +121,8 @@ class CloudAccountTest(TestCase):
     """Test cases for api.models.CloudAccount."""
 
     @patch("api.tasks.sources.notify_application_availability_task")
-    def test_delete_clount_deletes_user(self, mock_notify_sources):
-        """Test User is deleted if last clount is deleted."""
+    def test_delete_cloud_account_deletes_user(self, mock_notify_sources):
+        """Test User is deleted if last cloud account is deleted."""
         user = util_helper.generate_test_user()
         account_number = user.account_number
         aws_account_id = util_helper.generate_dummy_aws_account_id()
@@ -135,10 +135,10 @@ class CloudAccountTest(TestCase):
         self.assertFalse(User.objects.filter(account_number=account_number).exists())
 
     @patch("api.tasks.sources.notify_application_availability_task")
-    def test_delete_clount_doesnt_delete_user_for_two_clounts(
+    def test_delete_cloud_account_doesnt_delete_user_for_two_cloud_accounts(
         self, mock_notify_sources
     ):
-        """Test User is not deleted if it has more clounts left."""
+        """Test User is not deleted if it has more cloud accounts left."""
         user = util_helper.generate_test_user()
         account_number = user.account_number
         aws_account_id = util_helper.generate_dummy_aws_account_id()

--- a/cloudigrade/api/tests/util/test_calculate_max_concurrent_usage_from_runs.py
+++ b/cloudigrade/api/tests/util/test_calculate_max_concurrent_usage_from_runs.py
@@ -272,12 +272,12 @@ class CalculateMaxConcurrentUsageFromRunsTest(TestCase):
             },
         ]
 
-    def test_one_clount_one_run_one_day(self):
+    def test_one_cloud_account_one_run_one_day(self):
         """
-        Test with one clount having one run in one day.
+        Test with one cloud account having one run in one day.
 
-        This should result in two usages: one is for the user+clount and one is
-        for the user+no clount.
+        This should result in two usages: one is for the user+cloud account and one is
+        for the user+no cloud account.
         """
         instance = api_helper.generate_instance(self.account, image=self.image_rhel)
         run = api_helper.generate_single_run(
@@ -309,15 +309,15 @@ class CalculateMaxConcurrentUsageFromRunsTest(TestCase):
             expected_counts=expected_counts,
         )
 
-    def test_one_clount_one_run_two_days(self):
+    def test_one_cloud_account_one_run_two_days(self):
         """
-        Test with one clount having one run spanning two days.
+        Test with one cloud account having one run spanning two days.
 
         This should result in four usages:
-        - day 1 user and clount
-        - day 1 user and no clount
-        - day 2 user and clount
-        - day 2 user and no clount
+        - day 1 user and cloud account
+        - day 1 user and no cloud account
+        - day 2 user and cloud account
+        - day 2 user and no cloud account
         """
         instance = api_helper.generate_instance(self.account, image=self.image_rhel)
         run = api_helper.generate_single_run(
@@ -356,17 +356,17 @@ class CalculateMaxConcurrentUsageFromRunsTest(TestCase):
             expected_counts=expected_counts,
         )
 
-    def test_one_clount_one_run_with_no_end_two_days(self):
+    def test_one_cloud_account_one_run_with_no_end_two_days(self):
         """
-        Test with one clount having one run starting yesterday and no end.
+        Test with one cloud account having one run starting yesterday and no end.
 
         Since there is no known end date, we can only calculate dates to today.
 
         This should result in four usages:
-        - yesterday user and clount
-        - yesterday user and no clount
-        - today user and clount
-        - today user and no clount
+        - yesterday user and cloud account
+        - yesterday user and no cloud account
+        - today user and cloud account
+        - today user and no cloud account
         """
         instance = api_helper.generate_instance(self.account, image=self.image_rhel)
         today = get_today()

--- a/cloudigrade/internal/tests/views/test_availability_check.py
+++ b/cloudigrade/internal/tests/views/test_availability_check.py
@@ -64,7 +64,7 @@ class AvailabilityCheckViewTest(TestCase):
         self.assertTrue(self.account2.is_enabled)
         mock_notify_sources.delay.assert_called()
 
-    def test_availability_check_task_bad_clount_id(self):
+    def test_availability_check_task_bad_cloud_account_id(self):
         """Test that task properly handles deleted accounts."""
         with self.assertLogs("api.tasks", level="WARNING") as logs:
             enable_account(123456)

--- a/cloudigrade/util/tests/test_misc.py
+++ b/cloudigrade/util/tests/test_misc.py
@@ -69,8 +69,10 @@ class LockUserTaskTest(TransactionTestCase):
 
     @patch("api.clouds.aws.util.delete_cloudtrail")
     @patch("api.tasks.sources.notify_application_availability_task")
-    def test_delete_clount_lock(self, mock_notify_sources, mock_delete_cloudtrail):
-        """Test that deleting an clount inside a lock is successful."""
+    def test_delete_cloud_account_lock(
+        self, mock_notify_sources, mock_delete_cloudtrail
+    ):
+        """Test that deleting an account inside a lock is successful."""
         aws_account_id = util_helper.generate_dummy_aws_account_id()
         arn = util_helper.generate_dummy_arn(account_id=aws_account_id)
         account = api_helper.generate_cloud_account(
@@ -85,8 +87,8 @@ class LockUserTaskTest(TransactionTestCase):
         self.assertFalse(UserTaskLock.objects.filter(user=account.user).exists())
 
     @patch("api.tasks.sources.notify_application_availability_task")
-    def test_delete_clount_lock_exception(self, mock_notify_sources):
-        """Test that an exception when deleting a clount inside a lock rolls back."""
+    def test_delete_cloud_account_lock_exception(self, mock_notify_sources):
+        """Test that an exception when deleting an account inside a lock rolls back."""
         aws_account_id = util_helper.generate_dummy_aws_account_id()
         arn = util_helper.generate_dummy_arn(account_id=aws_account_id)
         account = api_helper.generate_cloud_account(


### PR DESCRIPTION
Long ago, we sometimes referred to cloud accounts as "clounts" in some conversational and shorthand contexts, but now its occasional use is inconsistent with the rest of our code, and its meaning is not obvious. I ran into this again while updating some old tests, and I decided it's finally time to purge this old slang.