### PR TITLE
Enable Azure lighthouse  registration assignment deletes

### DIFF
--- a/cloudigrade/util/azure/__init__.py
+++ b/cloudigrade/util/azure/__init__.py
@@ -8,15 +8,28 @@ from util.azure.identity import (
 
 
 # Azure Permissions
+#
 # Azure permissions or roles are defined via their object ids, this
 # unfortunately has the side effect of making it very hard to reference
 # what a specific id is, this section is a way to map these azure ids
 # to a developer readable name to be used in our template.
-# Reader - acdd72a7-3385-48ef-bd42-f606fba81ae7
+#
+# The role definition id's referenced here below are Azure
+# built-in roles. The id's are static in nature and are documented
+# here: https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+#
+# The Reader role allows us to view all resources as needed when doing the
+# initial azure vm discovery for managed tenant subscriptions.
+#
+# Reader:
 AZURE_READER_ROLE_ID = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
 
-# Managed Services Registration assignment
-# Delete Role - 91c1777a-f3dc-4fae-b103-61d183457e46
+# The Managed Services Registration assignment Delete Role allows us
+# to view the managed tenant lighthouse registration assignments and
+# provides us the ability to delete the customer managed tenant
+# delegation upon an azure account deletion.
+#
+# Managed Services Registration assignment Delete Role:
 AZURE_MS_REG_ASSIGNMENT_DELETE_ROLE_ID = "91c1777a-f3dc-4fae-b103-61d183457e46"
 
 # Azure Lighthouse ARM Template Offer

--- a/cloudigrade/util/azure/__init__.py
+++ b/cloudigrade/util/azure/__init__.py
@@ -15,6 +15,10 @@ from util.azure.identity import (
 # Reader - acdd72a7-3385-48ef-bd42-f606fba81ae7
 AZURE_READER_ROLE_ID = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
 
+# Managed Services Registration assignment
+# Delete Role - 91c1777a-f3dc-4fae-b103-61d183457e46
+AZURE_MS_REG_ASSIGNMENT_DELETE_ROLE_ID = "91c1777a-f3dc-4fae-b103-61d183457e46"
+
 # Azure Lighthouse ARM Template Offer
 ARM_TEMPLATE_NAME = f"cloudigrade-{settings.CLOUDIGRADE_ENVIRONMENT}"
 ARM_TEMPLATE = {
@@ -42,17 +46,27 @@ ARM_TEMPLATE = {
             "defaultValue": [
                 {
                     "principalId": f"{settings.AZURE_SP_OBJECT_ID}",
-                    "roleDefinitionId": f"{AZURE_READER_ROLE_ID}",
                     "principalIdDisplayName": f"{ARM_TEMPLATE_NAME}",
-                }
+                    "roleDefinitionId": f"{AZURE_READER_ROLE_ID}",
+                },
+                {
+                    "principalId": f"{settings.AZURE_SP_OBJECT_ID}",
+                    "principalIdDisplayName": f"{ARM_TEMPLATE_NAME}",
+                    "roleDefinitionId": f"{AZURE_MS_REG_ASSIGNMENT_DELETE_ROLE_ID}",
+                },
             ],
             "allowedValues": [
                 [
                     {
                         "principalId": f"{settings.AZURE_SP_OBJECT_ID}",
-                        "roleDefinitionId": f"{AZURE_READER_ROLE_ID}",
                         "principalIdDisplayName": f"{ARM_TEMPLATE_NAME}",
-                    }
+                        "roleDefinitionId": f"{AZURE_READER_ROLE_ID}",
+                    },
+                    {
+                        "principalId": f"{settings.AZURE_SP_OBJECT_ID}",
+                        "principalIdDisplayName": f"{ARM_TEMPLATE_NAME}",
+                        "roleDefinitionId": f"{AZURE_MS_REG_ASSIGNMENT_DELETE_ROLE_ID}",
+                    },
                 ]
             ],
         },

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -2277,7 +2277,7 @@ Response:
     HTTP/1.1 200 OK
     Access-Control-Allow-Origin: *
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 2017
+    Content-Length: 2357
     Content-Type: application/json
     Referrer-Policy: same-origin
     X-CLOUDIGRADE-REQUEST-ID: f93bd15d-1298-4424-b500-34a8acbbf0e6
@@ -2305,6 +2305,11 @@ Response:
                             "principalId": "691f0b3e-exam-ple3-b03f-6eb5120acabb",
                             "principalIdDisplayName": "cloudigrade-rest-api-examples",
                             "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+                        },
+                        {
+                            "principalId": "691f0b3e-exam-ple3-b03f-6eb5120acabb",
+                            "principalIdDisplayName": "cloudigrade-rest-api-examples",
+                            "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46"
                         }
                     ]
                 ],
@@ -2313,6 +2318,11 @@ Response:
                         "principalId": "691f0b3e-exam-ple3-b03f-6eb5120acabb",
                         "principalIdDisplayName": "cloudigrade-rest-api-examples",
                         "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+                    },
+                    {
+                        "principalId": "691f0b3e-exam-ple3-b03f-6eb5120acabb",
+                        "principalIdDisplayName": "cloudigrade-rest-api-examples",
+                        "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46"
                     }
                 ],
                 "type": "array"


### PR DESCRIPTION
- Adding the Azure Managed Services registration assignment delete role id to the lighthouse azure offer template, so service principals as referenced by the AZURE_SP_OBJECT_ID can remove a lighthouse customer delegation via the service provider's Azure portal UI.

For #1243