### PR TITLE
add ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API to playbook task for convenience with ephemeral deployments

### DIFF
--- a/deployment/playbooks/roles/clowder/tasks/clowder.yml
+++ b/deployment/playbooks/roles/clowder/tasks/clowder.yml
@@ -31,6 +31,7 @@
         --set-parameter "postigrade/IMAGE_TAG={{ lookup('env', 'POSTIGRADE_IMAGE_TAG') | default('latest', True) }}"  \
         --set-parameter "cloudigrade/CLOUDIGRADE_ENVIRONMENT={{ env }}" \
         --set-parameter "cloudigrade/DJANGO_SETTINGS_MODULE=config.settings.prod" \
+        --set-parameter "cloudigrade/ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API={{ lookup('env', 'ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API') | default('False', True) }}" \
         --set-parameter "cloudigrade/AWS_ACCESS_KEY_ID={{ lookup('env', 'AWS_ACCESS_KEY_ID') | b64encode }}" \
         --set-parameter "cloudigrade/AWS_SECRET_ACCESS_KEY={{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | b64encode }}" \
         --set-parameter "cloudigrade/CW_AWS_ACCESS_KEY_ID={{ lookup('env', 'AWS_ACCESS_KEY_ID') | b64encode }}" \
@@ -65,6 +66,7 @@
         --set-parameter "cloudigrade/IMAGE_TAG={{ (cloudigrade_deployment_host == 'local') | ternary(new_image_tag.stdout, 'latest') }}" \
         --set-parameter "cloudigrade/CLOUDIGRADE_ENVIRONMENT={{ env }}" \
         --set-parameter "cloudigrade/DJANGO_SETTINGS_MODULE=config.settings.prod" \
+        --set-parameter "cloudigrade/ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API={{ lookup('env', 'ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API') | default('False', True) }}" \
         --set-parameter "cloudigrade/AWS_ACCESS_KEY_ID={{ lookup('env', 'AWS_ACCESS_KEY_ID') | b64encode }}" \
         --set-parameter "cloudigrade/AWS_SECRET_ACCESS_KEY={{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | b64encode }}" \
         --set-parameter "cloudigrade/CW_AWS_ACCESS_KEY_ID={{ lookup('env', 'AWS_ACCESS_KEY_ID') | b64encode }}" \


### PR DESCRIPTION
Here's something I've been using locally for development.

Verified by _not_ having `ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API` set in my environment before calling the playbook, port-forwarding into a deployed pod, and trying to use the API:

```
❯ http localhost:8001/internal/api/cloudigrade/v1/syntheticdatarequests/ cloud_type=aws instance_count=1000 expires_at=2022-08-29T00:00
HTTP/1.1 404 Not Found
```

Then setting `export ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API=True` before rerunning the playbook again, port-forwarding, and trying the API:

```
❯ http localhost:8001/internal/api/cloudigrade/v1/syntheticdatarequests/ cloud_type=aws instance_count=1000 expires_at=2022-08-29T00:00
HTTP/1.1 201 Created
```