### PR TITLE
set gunicorn limit_request_field_size = 16384

### DIFF
--- a/cloudigrade/config/gunicorn.py
+++ b/cloudigrade/config/gunicorn.py
@@ -12,3 +12,6 @@ else:
 
 forwarded_allow_ips = "*"
 workers = 2
+
+# https://issues.redhat.com/browse/RHCLOUD-21245
+limit_request_field_size = 16384


### PR DESCRIPTION
As requested by
- https://issues.redhat.com/browse/RHCLOUD-21245
- https://docs.google.com/document/d/1GFhGUpQ-hVLb1c4-VxV0L5QUqqhii_aJx-BcEGKqW5s/edit
- https://docs.google.com/document/d/1snCLvZtj8X1UN7ZpUaxjXcEbs4T3vtSvk4QXphe2xkE/edit

See also Gunicorn docs: https://docs.gunicorn.org/en/stable/settings.html#limit-request-field-size