### PR TITLE
Assure only one SyncBucketLifeCycle runs at startup

### DIFF
--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -635,6 +635,15 @@ ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API = env.bool(
 )
 
 #####################################################################
+# leader run cached timing related configs for features
+
+# How long for a feature to expect to be running as a leader for
+LEADER_RUNNING_TTL_DEFAULT = env.int("LEADER_RUNNING_TTL_DEFAULT", default=60)
+
+# How long do we take a feature completed as a leader for
+LEADER_COMPLETED_TTL_DEFAULT = env.int("LEADER_COMPLETED_TTL_DEFAULT", default=300)
+
+#####################################################################
 # cloudigrade authentication-related configs
 
 VERBOSE_INSIGHTS_IDENTITY_HEADER_LOGGING = env.bool(

--- a/cloudigrade/util/leaderrun.py
+++ b/cloudigrade/util/leaderrun.py
@@ -32,7 +32,7 @@ class LeaderRun(object):
         cache.set(self.completed_key, None)
 
     def is_running(self):
-        """Return True if the feature is running."""
+        """Return Feature start time if the feature is running, None otherwise."""
         return cache.get(self.running_key)
 
     def wait_for_completion(self):
@@ -48,7 +48,7 @@ class LeaderRun(object):
         cache.set(self.running_key, None)
 
     def has_completed(self):
-        """Return True if the feature has completed."""
+        """Return Feature completion time, None otherwise."""
         return cache.get(self.completed_key)
 
     def reset(self):

--- a/cloudigrade/util/leaderrun.py
+++ b/cloudigrade/util/leaderrun.py
@@ -1,6 +1,7 @@
 """Helper methods for helping track running/completed product features as leaders."""
 import datetime
 import time
+from contextlib import contextmanager
 
 from django.conf import settings
 from django.core.cache import cache
@@ -57,3 +58,12 @@ class LeaderRun(object):
         # wasn't seeing the cache.deletes across the pods somehow.
         cache.set(self.running_key, None)
         cache.set(self.completed_key, None)
+
+    @contextmanager
+    def run(self):
+        """Yield caller's block and guarantee the completion state."""
+        self.set_as_running()
+        try:
+            yield
+        finally:
+            self.set_as_completed()

--- a/cloudigrade/util/leaderrun.py
+++ b/cloudigrade/util/leaderrun.py
@@ -1,0 +1,53 @@
+"""Helper methods for helping track running/completed product features as leaders."""
+import datetime
+import time
+
+from django.conf import settings
+from django.core.cache import cache
+
+LEADER_KEY_PREFIX = f"cloudigrade-{settings.CLOUDIGRADE_ENVIRONMENT}-leader-"
+
+
+class LeaderRun(object):
+    """Helper class for managing run/completed states of features as leaders."""
+
+    def __init__(self, feature_key, **kwargs):
+        """Initialize a LeaderRun object."""
+        self.key = feature_key
+        self.base_key = f"{LEADER_KEY_PREFIX}-{self.key}"
+        self.running_key = f"{self.base_key}-running"
+        self.completed_key = f"{self.base_key}-completed"
+        self.leader_running_ttl = settings.LEADER_RUNNING_TTL_DEFAULT
+        self.leader_completed_ttl = settings.LEADER_COMPLETED_TTL_DEFAULT
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def _now(self):
+        """Return the current time for date stamping the keys."""
+        return datetime.datetime.now()
+
+    def set_as_running(self):
+        """Set the feature as running."""
+        cache.set(self.running_key, self._now(), timeout=self.leader_running_ttl)
+
+    def is_running(self):
+        """Return True if the feature is running."""
+        return cache.get(self.running_key)
+
+    def wait_for_completion(self):
+        """Wait for the feature run to complete."""
+        # In case of script errors and not a clean completion of the leader run,
+        # this method will complete upon the normal expiration of the cached key.
+        while cache.get(self.running_key):
+            time.sleep(1)
+
+    def set_as_completed(self):
+        """Set the feature as done running and completed."""
+        cache.set(self.running_key, None)
+        return cache.set(
+            self.completed_key, self._now(), timeout=self.leader_completed_ttl
+        )
+
+    def has_completed(self):
+        """Return True if the feature has completed."""
+        return cache.get(self.completed_key)

--- a/cloudigrade/util/management/commands/syncbucketlifecycle.py
+++ b/cloudigrade/util/management/commands/syncbucketlifecycle.py
@@ -1,8 +1,14 @@
 """Ensure S3 bucket lifecycle settings are up to date."""
+import logging
+
 import boto3
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.translation import gettext as _
+
+from util.leaderrun import LeaderRun
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -17,6 +23,17 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle the command execution."""
+        leader = LeaderRun("sync-bucket-lifecycle")
+        if leader.has_completed():
+            logger.info(_("SyncBucketLifeCycle: Already completed, Skipping"))
+            return
+        if leader.is_running():
+            logger.info(_("SyncBucketLifeCycle: Already running, Skipping"))
+            leader.wait_for_completion()
+            return
+
+        logger.info(_("SyncBucketLifeCycle: Executing"))
+        leader.set_as_running()
         s3 = boto3.resource("s3")
         for bucket_name in self.bucket_names:
             bucket_lifecycle_configuration = s3.BucketLifecycleConfiguration(
@@ -48,3 +65,4 @@ class Command(BaseCommand):
                     ]
                 }
             )
+        leader.set_as_completed()

--- a/cloudigrade/util/management/commands/syncbucketlifecycle.py
+++ b/cloudigrade/util/management/commands/syncbucketlifecycle.py
@@ -33,36 +33,37 @@ class Command(BaseCommand):
             return
 
         logger.info(_("SyncBucketLifeCycle: Executing"))
-        leader.set_as_running()
-        s3 = boto3.resource("s3")
-        for bucket_name in self.bucket_names:
-            bucket_lifecycle_configuration = s3.BucketLifecycleConfiguration(
-                bucket_name
-            )
-            bucket_lifecycle_configuration.put(
-                LifecycleConfiguration={
-                    "Rules": [
-                        {
-                            "Expiration": {"Days": settings.AWS_S3_BUCKET_LC_MAX_AGE},
-                            "ID": settings.AWS_S3_BUCKET_LC_NAME,
-                            "Status": "Enabled",
-                            # This looks weird, empty prefix and filter and all
-                            # but without it, AWS throws an equivalent of a 400
-                            "Filter": {"Prefix": ""},
-                            "Transitions": [
-                                {
-                                    "Days": settings.AWS_S3_BUCKET_LC_IA_TRANSITION,
-                                    "StorageClass": "STANDARD_IA",
+        with leader.run():
+            s3 = boto3.resource("s3")
+            for bucket_name in self.bucket_names:
+                bucket_lifecycle_configuration = s3.BucketLifecycleConfiguration(
+                    bucket_name
+                )
+                bucket_lifecycle_configuration.put(
+                    LifecycleConfiguration={
+                        "Rules": [
+                            {
+                                "Expiration": {
+                                    "Days": settings.AWS_S3_BUCKET_LC_MAX_AGE
                                 },
-                                {
-                                    "Days": (
-                                        settings.AWS_S3_BUCKET_LC_GLACIER_TRANSITION
-                                    ),
-                                    "StorageClass": "GLACIER",
-                                },
-                            ],
-                        }
-                    ]
-                }
-            )
-        leader.set_as_completed()
+                                "ID": settings.AWS_S3_BUCKET_LC_NAME,
+                                "Status": "Enabled",
+                                # This looks weird, empty prefix and filter and all
+                                # but without it, AWS throws an equivalent of a 400
+                                "Filter": {"Prefix": ""},
+                                "Transitions": [
+                                    {
+                                        "Days": settings.AWS_S3_BUCKET_LC_IA_TRANSITION,
+                                        "StorageClass": "STANDARD_IA",
+                                    },
+                                    {
+                                        "Days": (
+                                            settings.AWS_S3_BUCKET_LC_GLACIER_TRANSITION
+                                        ),
+                                        "StorageClass": "GLACIER",
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                )

--- a/cloudigrade/util/tests/test_leaderrun.py
+++ b/cloudigrade/util/tests/test_leaderrun.py
@@ -1,0 +1,70 @@
+"""Collection of tests for ``util.leaderrun.LeaderRun`` class."""
+import datetime
+
+import faker
+from django.conf import settings
+from django.test import TestCase
+
+from util.leaderrun import LeaderRun
+
+_faker = faker.Faker()
+
+
+class LeaderRunTest(TestCase):
+    """LeaderRun class test cases."""
+
+    def test_default_ttl(self):
+        """Assert that the ttl for running and completed are the defaults."""
+        leader = LeaderRun(_faker.slug())
+        self.assertEqual(leader.leader_running_ttl, settings.LEADER_RUNNING_TTL_DEFAULT)
+        self.assertEqual(
+            leader.leader_completed_ttl, settings.LEADER_COMPLETED_TTL_DEFAULT
+        )
+
+    def test_custom_ttl(self):
+        """Assert that LeaderRun support custom ttl."""
+        run_ttl = _faker.pyint()
+        completed_ttl = _faker.pyint()
+        leader = LeaderRun(
+            _faker.slug(),
+            leader_running_ttl=run_ttl,
+            leader_completed_ttl=completed_ttl,
+        )
+        self.assertEqual(leader.leader_running_ttl, run_ttl)
+        self.assertEqual(leader.leader_completed_ttl, completed_ttl)
+
+    def test_set_as_running_succeeds(self):
+        """Assert that set_as_running returns marks that feature is running."""
+        leader = LeaderRun(_faker.slug())
+        leader.set_as_running()
+        self.assertTrue(leader.is_running())
+        self.assertFalse(leader.has_completed())
+
+    def test_is_running_false_for_non_started_features(self):
+        """Assert that is_running is false for features that are not started."""
+        leader = LeaderRun(_faker.slug())
+        self.assertFalse(leader.is_running())
+
+    def test_is_running_is_a_datetime(self):
+        """Assert is_running gives us a datetime (e.g. time started)."""
+        leader = LeaderRun(_faker.slug())
+        leader.set_as_running()
+        self.assertIsInstance(leader.is_running(), datetime.datetime)
+
+    def test_set_as_completed_succeeds(self):
+        """Assert that set_as_completed marks feature has completed."""
+        leader = LeaderRun(_faker.slug())
+        leader.set_as_completed()
+        self.assertTrue(leader.has_completed())
+        self.assertFalse(leader.is_running())
+
+    def test_has_completed_false_for_non_started_features(self):
+        """Assert that has_completed is false for features that have not started."""
+        leader = LeaderRun(_faker.slug())
+        self.assertFalse(leader.has_completed())
+
+    def test_has_completed_is_a_datetime(self):
+        """Assert has_completed gives us a datetime (e.g. time completed)."""
+        leader = LeaderRun(_faker.slug())
+        leader.set_as_completed()
+        self.assertIsInstance(leader.has_completed(), datetime.datetime)

--- a/cloudigrade/util/tests/test_leaderrun.py
+++ b/cloudigrade/util/tests/test_leaderrun.py
@@ -68,3 +68,11 @@ class LeaderRunTest(TestCase):
         leader = LeaderRun(_faker.slug())
         leader.set_as_completed()
         self.assertIsInstance(leader.has_completed(), datetime.datetime)
+
+    def test_run(self):
+        """Assert the leader.run completes successfully after a failure."""
+        leader = LeaderRun(_faker.slug())
+        with self.assertRaises(RuntimeError):
+            with leader.run():
+                raise RuntimeError("leader exception")
+        self.assertTrue(leader.has_completed())

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -184,6 +184,10 @@ objects:
           value: ${HOUNDIGRADE_ECS_FAMILY_NAME}
         - name: INSPECTION_CLUSTER_INSTANCE_AGE_LIMIT
           value: ${INSPECTION_CLUSTER_INSTANCE_AGE_LIMIT}
+        - name: LEADER_RUNNING_TTL_DEFAULT
+          value: ${LEADER_RUNNING_TTL_DEFAULT}
+        - name: LEADER_COMPLETED_TTL_DEFAULT
+          value: ${LEADER_COMPLETED_TTL_DEFAULT}
         - name: CLOUDIGRADE_VERSION
           value: ${CLOUDIGRADE_VERSION}
         - name: CLOUDIGRADE_ENVIRONMENT
@@ -1457,6 +1461,14 @@ parameters:
   displayName: Houndigrade Sentry Environment
   required: true
   value: ephemeral
+- name: LEADER_RUNNING_TTL_DEFAULT
+  displayName: Leader Running default TTL in seconds
+  required: true
+  value: '60'
+- name: LEADER_COMPLETED_TTL_DEFAULT
+  displayName: Leader Completed default TTL in seconds
+  required: true
+  value: '300'
 - name: LISTENER_ENABLE_SENTRY
   displayName: Listener Sentry Enabled
   required: true


### PR DESCRIPTION
- Adding support for running cloudigrade features as leaders (run once and only once across the cloudigrade pods). Manages run/completion times via the global Redis and adds helper methods for ease of use.

- This is initially used to assure that one and only one SyncBucketLifeCycle initialization script is run when multiple API pods are starting up.

The helper class LeaderRun introduced here is to simplify the usage so we can leverage this for any other feature code to run as a Leader.
See the diffs of `util/management/commands/syncbucketlifecycle.py` in [PR diffs](https://github.com/cloudigrade/cloudigrade/pull/1341/files#diff-1ab40b8c42ba73dd24974c97b6761f81f65b43d7a355a477ac71bbb1e4fefe46) for how we use it for SyncBucketLifeCycle.


For #1244 