### PR TITLE
fix incorrect type match for Azure subscription IDs

### DIFF
--- a/cloudigrade/api/clouds/azure/models.py
+++ b/cloudigrade/api/clouds/azure/models.py
@@ -279,7 +279,7 @@ def delete_lighthouse_registration(*args, **kwargs):
             id_list = reg_assignment.id.split("/")
             if state == "Succeeded" and "/".join(id_list[1:3]) == tenant_scope:
                 if registration_name:
-                    logger.warn(
+                    logger.warning(
                         _(
                             "Found multiple lighthouse registrations for"
                             " tenant subscription %s, skipping deleting the"
@@ -303,7 +303,7 @@ def delete_lighthouse_registration(*args, **kwargs):
                     },
                 )
     except ClientAuthenticationError as e:
-        logger.warn(
+        logger.warning(
             _(
                 "ClientAuthenticationError while trying to find the lighthouse"
                 " registration assignment for tenant subscription %s - %s"

--- a/cloudigrade/util/azure/identity.py
+++ b/cloudigrade/util/azure/identity.py
@@ -1,4 +1,6 @@
 """Helper utility module to wrap up common Azure Identity operations."""
+from uuid import UUID
+
 from azure.identity import EnvironmentCredential
 from azure.mgmt.resource import SubscriptionClient
 from django.conf import settings
@@ -14,8 +16,13 @@ def get_cloudigrade_subscription_id():
     return settings.AZURE_SUBSCRIPTION_ID
 
 
-def get_cloudigrade_available_subscriptions():
-    """Fetch all azure subscription ids that cloudigrade has access to."""
+def get_cloudigrade_available_subscriptions() -> list[UUID]:
+    """
+    Fetch all Azure subscription IDs that cloudigrade has access to.
+
+    Returns:
+        list[uuid.UUID]: list of UUIDs of Azure subscription IDs cloudigrade can access
+    """
     subs_client = SubscriptionClient(get_cloudigrade_credentials())
     subscriptions = []
     subscription_ids = []
@@ -24,6 +31,6 @@ def get_cloudigrade_available_subscriptions():
         subscriptions.append(sub.as_dict())
 
     for sub in subscriptions:
-        subscription_ids.append(sub.get("subscription_id"))
+        subscription_ids.append(UUID(sub.get("subscription_id")))
 
     return subscription_ids

--- a/cloudigrade/util/tests/azure/test_identity.py
+++ b/cloudigrade/util/tests/azure/test_identity.py
@@ -1,5 +1,6 @@
 """Collection of tests for ``util.azure.identity`` module."""
 from unittest.mock import Mock, patch
+from uuid import UUID
 
 from django.test import TestCase
 
@@ -46,8 +47,8 @@ class UtilAzureIdentityTest(TestCase):
         mock_customer_sub.as_dict.return_value = customer_sub_dict
         mock_cloudigrade_sub.as_dict.return_value = cloudigrade_sub_dict
 
-        self.customer_subscription_id = "d9812b28-6286-4501-9cd5-f43b2a455364"
-        self.cloudigrade_subscription_id = "03cd596c-179c-4191-985a-4bc6256f9126"
+        self.customer_subscription_id = UUID("d9812b28-6286-4501-9cd5-f43b2a455364")
+        self.cloudigrade_subscription_id = UUID("03cd596c-179c-4191-985a-4bc6256f9126")
         self.subscriptions_response = [
             mock_customer_sub,
             mock_cloudigrade_sub,


### PR DESCRIPTION
This fixes an issue where `AzureCloudAccount.enable()` might never work after the initial creation of the `AzureCloudAccount` object. `AzureCloudAccount.subscription_id` returns a `uuid.UUID`, but the return value from `get_cloudigrade_available_subscriptions` was a list of plain `str`s. This means that future calls to `enable` would never succeed and would always produce an error.

This fix simply changes that returned list to include `uuid.UUID` objects instead of `str`s. In general, when we compare UUIDs, we should be comparing `uuid.UUID` _objects_ since equivalent UUIDs could have strings formatted differently and fail equivalency checks.

I added a type hint to `get_cloudigrade_available_subscriptions`, but we don't enforce type checking anywhere yet. Maybe some day in the future we will. For now, it's just for our IDEs to remind us in development.

Also, as I was reviewing code around Azure and UUIDs for this change, I also spotted two nearby `logger.warn`s that I corrected to `logger.warning` because `warn` is an old deprecated method.