### PR TITLE
Removing the cloudigrade-metrics deployment.

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -861,59 +861,6 @@ objects:
           value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
-    - name: metrics
-      #
-      # Component cloudigrade-metrics deployment:
-      #
-      minReplicas: ${{CELERY_METRICS_REPLICA_COUNT}}
-      autoscaler:
-        externalHPA: true
-      revisionHistoryLimit: 10
-      webServices:
-        public:
-          enabled: true
-      podSpec:
-        image: ${CELERY_METRICS_IMAGE}:${CELERY_METRICS_IMAGE_TAG}
-        imagePullPolicy: Always
-        livenessProbe:
-          exec:
-            command:
-              - /bin/sh
-              - -c
-              - '[[ $(ps axo command | grep "^python" | grep -c "cli.py") -eq 1 ]]'
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 8000
-            scheme: HTTP
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: ${{CELERY_METRICS_READINESS_TIMEOUT}}
-        resources:
-          limits:
-            cpu: ${CELERY_METRICS_LIMITS_CONTAINER_CPU_LIMIT}
-            memory: ${CELERY_METRICS_LIMITS_CONTAINER_MEM_LIMIT}
-          requests:
-            cpu: ${CELERY_METRICS_LIMITS_CONTAINER_CPU_REQUEST}
-            memory: ${CELERY_METRICS_LIMITS_CONTAINER_MEM_REQUEST}
-        env:
-        - name: CELERY_METRICS_LOG_LEVEL
-          value: ${CELERY_METRICS_LOG_LEVEL}
-        - name: CELERY_METRICS_PORT
-          value: ${CELERY_METRICS_PORT}
-        - name: CELERY_METRICS_RETRY_INTERVAL
-          value: ${CELERY_METRICS_RETRY_INTERVAL}
-        - name: CLOUDIGRADE_ENVIRONMENT
-          value: ${CLOUDIGRADE_ENVIRONMENT}
-        - name: OSD_REDEPLOY_TRIGGER
-          value: ${OSD_REDEPLOY_TRIGGER}
     - name: worker
       #
       # Component cloudigrade-worker deployment:
@@ -1279,25 +1226,6 @@ objects:
         target:
           type: Utilization
           averageUtilization: ${{CELERY_TARGET_AVERAGE_CPU_UTILIZATION}}
-- apiVersion: autoscaling/v2
-  kind: HorizontalPodAutoscaler
-  metadata:
-    name: cloudigrade-metrics-cpu
-  spec:
-    scaleTargetRef:
-      apiVersion: apps/v1
-      kind: Deployment
-      name: cloudigrade-metrics
-    minReplicas: ${{CELERY_METRICS_REPLICA_COUNT}}
-    maxReplicas: ${{CELERY_METRICS_REPLICA_COUNT_MAX}}
-    metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: ${{CELERY_METRICS_TARGET_AVERAGE_CPU_UTILIZATION}}
-
 parameters:
 #
 # Ephemeral Secret Values:
@@ -1535,61 +1463,6 @@ parameters:
   displayName: Cloudigrade Listener Replica Count
   required: true
   value: '1'
-#
-# Component cloudigrade-metrics parameters
-#
-- name: CELERY_METRICS_IMAGE
-  displayName: Celery Metrics Image
-  required: true
-  value: quay.io/cloudservices/celery-exporter-container
-- name: CELERY_METRICS_IMAGE_TAG
-  displayName: Celery Metrics Image Tag
-  required: true
-  value: 7729ce8
-- name: CELERY_METRICS_READINESS_TIMEOUT
-  displayName: Celery Metrics readiness probe timeout in seconds
-  required: true
-  value: '5'
-- name: CELERY_METRICS_LIMITS_CONTAINER_CPU_LIMIT
-  displayName: Cloudigrade Celery Metrics Container CPU Limit
-  required: true
-  value: 100m
-- name: CELERY_METRICS_LIMITS_CONTAINER_CPU_REQUEST
-  displayName: Cloudigrade Celery Metrics Container CPU Request
-  required: true
-  value: 100m
-- name: CELERY_METRICS_LIMITS_CONTAINER_MEM_LIMIT
-  displayName: Cloudigrade Celery Metrics Container Memory Limit
-  required: true
-  value: 128Mi
-- name: CELERY_METRICS_LIMITS_CONTAINER_MEM_REQUEST
-  displayName: Cloudigrade Celery Metrics Container Memory Request
-  required: true
-  value: 100Mi
-- name: CELERY_METRICS_LOG_LEVEL
-  displayName: Celery Metrics Log Level
-  required: true
-  value: 'INFO'
-- name: CELERY_METRICS_PORT
-  displayName: Celery Metrics Port
-  required: true
-  value: '9808'
-- name: CELERY_METRICS_REPLICA_COUNT
-  displayName: Cloudigrade Celery Metrics Replica Count
-  required: true
-  value: '1'
-- name: CELERY_METRICS_REPLICA_COUNT_MAX
-  displayName: Cloudigrade Celery Metrics Replica Count Max
-  required: true
-  value: '3'
-- name: CELERY_METRICS_TARGET_AVERAGE_CPU_UTILIZATION
-  displayName: Cloudigrade Celery Metrics Target Average CPU Utilization
-  required: true
-  value: '60'
-- name: CELERY_METRICS_RETRY_INTERVAL
-  displayName: Celery Metrics Retry Interval in seconds
-  required: true
-  value: '5'
 #
 # Component cloudigrade-worker parameters:
 #


### PR DESCRIPTION

Removing the cloudigrade-metrics deployment as for now we only need what's provided via /internal/metrics from the cloudigrade-api pods.

See: https://github.com/cloudigrade/cloudigrade/issues/1349