### PR TITLE
wait for migrations to complete before starting celery beat and celery worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=build /opt/cloudigrade/.venv/ .venv/
 # Copy in cloudigrade
 COPY deployment/playbooks/ ./playbooks
 COPY deployment/scripts/cloudigrade_init.sh ./scripts/cloudigrade_init.sh
+COPY deployment/scripts/wait_for_migrations.sh ./scripts/wait_for_migrations.sh
 COPY cloudigrade .
 
 EXPOSE 8000

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -344,6 +344,7 @@ objects:
           - /bin/sh
           - -c
           - >
+            /bin/sh /opt/cloudigrade/scripts/wait_for_migrations.sh &&
             celery
             --app config
             beat
@@ -878,6 +879,7 @@ objects:
           - /bin/sh
           - -c
           - >
+            /bin/sh /opt/cloudigrade/scripts/wait_for_migrations.sh &&
             celery
             --app config
             worker

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -356,7 +356,7 @@ objects:
             command:
               - /bin/sh
               - -c
-              - 'ps axo command | grep -v grep | grep python'
+              - 'pgrep celery'
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -367,7 +367,7 @@ objects:
             command:
               - /bin/sh
               - -c
-              - '[[ $(ps axo command | grep "[p]ython" | grep celery | grep -c beat) -eq 1 ]]'
+              - '[[ $(pgrep -a celery | grep -c beat) -eq 1 ]]'
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -895,7 +895,7 @@ objects:
             command:
               - /bin/sh
               - -c
-              - 'ps axo command | grep -v grep | grep python'
+              - 'pgrep celery'
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -906,7 +906,7 @@ objects:
             command:
               - /bin/sh
               - -c
-              - '[[ $(ps axo command | grep "[p]ython" | grep celery | grep -c worker) -eq 1 ]]'
+              - '[[ $(pgrep -a celery | grep -c worker) -eq 1 ]]'
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/deployment/scripts/wait_for_migrations.sh
+++ b/deployment/scripts/wait_for_migrations.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Wait until the database is reachable and all Django migrations have completed.
+
+waitForMigrations() {
+    while ! python3 ./manage.py migrate --plan --check; do
+        echo "$(date '+%Y-%m-%dT%H.%M.%S') WARNING Database migrations have not yet completed." >&2
+        sleep 5
+    done
+}
+
+waitForMigrations

--- a/deployment/scripts/wait_for_migrations.sh
+++ b/deployment/scripts/wait_for_migrations.sh
@@ -2,7 +2,7 @@
 # Wait until the database is reachable and all Django migrations have completed.
 
 waitForMigrations() {
-    while ! python3 ./manage.py migrate --plan --check; do
+    while ! CLOUDIGRADE_LOG_LEVEL=ERROR python3 ./manage.py migrate --check; do
         echo "$(date '+%Y-%m-%dT%H.%M.%S') WARNING Database migrations have not yet completed." >&2
         sleep 5
     done


### PR DESCRIPTION
This adds an extra step to the container commands for `cloudigrade-beat` and `cloudigrade-worker` that will wait for any pending Django migrations to complete before starting either `celery` command.

This is necessary because it seems that _sometimes_ starting celery without a fully populated database will result in celery logging and error but then hanging forever instead of exiting. When that happens, OpenShift's liveness and readiness checks will think that the pod is okay, and it will leave the pod running in this broken state. If the beat is broken like that, then scheduled tasks (like `persist_inspection_cluster_results_task` will never execute).

I believe that's been happening to some of our `pr_check.sh` deployments and is responsible for some of our flaky `ci.ext` failures. The `ci.ext` tests in the final 25% (where it commonly fails) require the full inspection process to complete. If the beat is broken as described above, then inspection would complete all the way through houndigrade running, but cloudigrade would never pick up houndigrade's results to complete the full process.