### PR TITLE
Adding support for Cloudigrade Database table metrics

### DIFF
--- a/cloudigrade/internal/prometheus.py
+++ b/cloudigrade/internal/prometheus.py
@@ -92,6 +92,9 @@ class CachedMetricsRegistry:
         """Initialize Database table size metrics."""
         if not self.db_is_pg():
             # Currently only supports the Postgres database.
+            logger.warning(
+                "Database table size metrics is only available with Postgres"
+            )
             return
         gauge = Gauge(
             DB_TABLE_SIZE_METRIC_NAME,
@@ -114,6 +117,9 @@ class CachedMetricsRegistry:
         """Initialize Database table number of rows metrics."""
         if not self.db_is_pg():
             # Currently only supports the Postgres database.
+            logger.warning(
+                "Database table rows metrics is only available with Postgres"
+            )
             return
         gauge = Gauge(
             DB_TABLE_ROWS_METRIC_NAME,

--- a/cloudigrade/internal/tests/test_prometheus.py
+++ b/cloudigrade/internal/tests/test_prometheus.py
@@ -1,6 +1,6 @@
 """Collection of tests for the internal.prometheus module."""
 import itertools
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import faker
 from django.test import TestCase, override_settings
@@ -125,6 +125,99 @@ class InternalPrometheusTestCase(TestCase):
             registry._initialize_celery_queue_length_metrics()
             self.assertIn(
                 prometheus.CELERY_QUEUE_LENGTH_METRIC_NAME,
+                registry.get_registered_metrics_names(),
+            )
+            mock_gauge.assert_called_once()
+            mock_gauge_instance = mock_gauge.return_value
+            actual_labels_calls = mock_gauge_instance.labels.mock_calls
+            for expected_labels_call in expected_labels_calls:
+                self.assertIn(expected_labels_call, actual_labels_calls)
+
+    def test_initialize_db_table_size_metrics(self):
+        """
+        Test Database table size metrics are created as expected.
+
+        Normally the _initialize_db_table_size_metrics function never creates the
+        prometheus gauge by unit tests because unit tests are not configured to
+        use a Postgres database. This test short-circuits the database check and
+        sql statement executions to make metrics initialization possible.
+        """
+        fake_table_sizes = [
+            [_faker.slug(), 1024 * _faker.random_int(min=1, max=256)],
+            [_faker.slug(), 1024 * _faker.random_int(min=1, max=256)],
+        ]
+        expected_labels_calls = [
+            call(table_name=table_name) for table_name, table_size in fake_table_sizes
+        ]
+
+        patched_custom_gauge_metrics = {}
+        with patch(
+            "internal.prometheus.CachedMetricsRegistry._gauge_metrics",
+            patched_custom_gauge_metrics,
+        ), patch("internal.prometheus.Gauge") as mock_gauge, patch(
+            "internal.prometheus.CachedMetricsRegistry.db_is_pg",
+        ) as mock_db_is_pg, patch(
+            "internal.prometheus.connection"
+        ) as mock_connection:
+            mock_db_is_pg.return_value = True
+            mock_cursor = MagicMock()
+            mock_connection.cursor.return_value = mock_cursor
+            mock_cursor.execute.return_value = None
+            mock_cursor.fetchall.return_value = fake_table_sizes
+
+            from internal import prometheus
+
+            registry = prometheus.CachedMetricsRegistry()
+            registry._initialize_db_table_size_metrics()
+            self.assertIn(
+                prometheus.DB_TABLE_SIZE_METRIC_NAME,
+                registry.get_registered_metrics_names(),
+            )
+            mock_gauge.assert_called_once()
+            mock_gauge_instance = mock_gauge.return_value
+            actual_labels_calls = mock_gauge_instance.labels.mock_calls
+            for expected_labels_call in expected_labels_calls:
+                self.assertIn(expected_labels_call, actual_labels_calls)
+
+    def test_initialize_db_table_rows_metrics(self):
+        """
+        Test Database table rows metrics are created as expected.
+
+        Normally the _initialize_db_table_rows_metrics function never creates the
+        prometheus gauge by unit tests because unit tests are not configured to
+        use a Postgres database. This test short-circuits the database check and
+        sql statement executions to make metrics initialization possible.
+        """
+        fake_table_rows = [
+            [_faker.slug(), _faker.random_int(min=1, max=16384)],
+            [_faker.slug(), _faker.random_int(min=1, max=16384)],
+            [_faker.slug(), _faker.random_int(min=1, max=16384)],
+        ]
+        expected_labels_calls = [
+            call(table_name=table_name) for table_name, table_rows in fake_table_rows
+        ]
+
+        patched_custom_gauge_metrics = {}
+        with patch(
+            "internal.prometheus.CachedMetricsRegistry._gauge_metrics",
+            patched_custom_gauge_metrics,
+        ), patch("internal.prometheus.Gauge") as mock_gauge, patch(
+            "internal.prometheus.CachedMetricsRegistry.db_is_pg",
+        ) as mock_db_is_pg, patch(
+            "internal.prometheus.connection"
+        ) as mock_connection:
+            mock_db_is_pg.return_value = True
+            mock_cursor = MagicMock()
+            mock_connection.cursor.return_value = mock_cursor
+            mock_cursor.execute.return_value = None
+            mock_cursor.fetchall.return_value = fake_table_rows
+
+            from internal import prometheus
+
+            registry = prometheus.CachedMetricsRegistry()
+            registry._initialize_db_table_rows_metrics()
+            self.assertIn(
+                prometheus.DB_TABLE_ROWS_METRIC_NAME,
                 registry.get_registered_metrics_names(),
             )
             mock_gauge.assert_called_once()


### PR DESCRIPTION
- Adding support for Cloudigrade Database table size (in bytes) and the number of rows (live rows) in the Prometheus /internal/metrics endpoint.

- These are to be used by an updated Grafana dashboard to show a DB percentage space used, but also displaying 2 charts listing all table sizes and number of rows to hopefully quickly determine which table could be causing chewing up large amounts of disk space.

For: https://github.com/cloudigrade/cloudigrade/issues/1333
