### PR TITLE
ISSUE-1206 Update Azure Instances Hourly

### DIFF
--- a/cloudigrade/api/clouds/azure/tasks/__init__.py
+++ b/cloudigrade/api/clouds/azure/tasks/__init__.py
@@ -27,4 +27,6 @@ from api.clouds.azure.tasks.maintenance import repopulate_azure_instance_mapping
 from api.clouds.azure.tasks.onboarding import (
     check_azure_subscription_and_create_cloud_account,
     initial_azure_vm_discovery,
+    update_azure_instance_events,
+    update_azure_instance_events_for_account,
 )

--- a/cloudigrade/api/clouds/azure/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/azure/tasks/onboarding.py
@@ -16,7 +16,7 @@ from api.clouds.azure.util import (
 )
 from api.models import User
 from util.azure.vm import get_vms_for_subscription
-from util.celery import retriable_shared_task
+from util.celery import retriable_shared_task, shared_task
 from util.misc import lock_task_for_user_ids
 
 logger = logging.getLogger(__name__)
@@ -193,3 +193,46 @@ def initial_azure_vm_discovery(azure_cloud_account_id):
         )
         create_initial_azure_instance_events(cloud_account, vms_data)
         return
+
+
+@shared_task(name="api.clouds.azure.tasks.update_azure_instance_events")
+def update_azure_instance_events():
+    """Update the status of VM/VMSS instances across known Azure cloud accounts."""
+    logger.info(
+        _("Starting update_azure_instance_events for known Azure cloud accounts"),
+    )
+
+    # Get the VM info for each cloud account
+    for cloud_account in AzureCloudAccount.objects.all():
+        logger.info(
+            _("Updating instance info for account: %s"), cloud_account.cloud_account_id
+        )
+        update_azure_instance_events_for_account.delay(cloud_account.cloud_account_id)
+
+
+@shared_task(name="api.clouds.azure.tasks.update_azure_instance_events_for_account")
+def update_azure_instance_events_for_account(cloud_account_id):
+    """
+    Update the InstanceEvents for all instances in the specific Azure Cloud Account.
+
+    Args:
+        cloud_account_id (UUID): The subscription ID for the Azure Cloud Account.
+
+    Returns:
+        None: Run as an asynchronous Celery task.
+    """
+    try:
+        cloud_account = AzureCloudAccount.objects.get(subscription_id=cloud_account_id)
+    except AzureCloudAccount.DoesNotExist:
+        # AzureCloudAccount could have been deleted prior to calling/running task
+        logger.info(
+            _(
+                "Azure Cloud Account %(cloud_account_id)s not found; "
+                "skipping instance events update"
+            ),
+            {"cloud_account_id": cloud_account_id},
+        )
+        return
+
+    vms_info = get_vms_for_subscription(cloud_account.subscription_id)
+    create_initial_azure_instance_events(cloud_account, vms_info)

--- a/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_update_azure_instance_events.py
+++ b/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_update_azure_instance_events.py
@@ -1,0 +1,75 @@
+"""Tests the azure.tasks.onboarding.update_azure_instance_events function."""
+from unittest.mock import call, patch
+
+import faker
+from django.test import TestCase
+
+from api import AZURE_PROVIDER_STRING
+from api.clouds.azure.tasks.onboarding import (
+    update_azure_instance_events,
+    update_azure_instance_events_for_account,
+)
+from api.tests import helper as account_helper
+
+_faker = faker.Faker()
+
+log_prefix = "api.clouds.azure.tasks.onboarding"
+
+
+class UpdateAzureInstanceEvents(TestCase):
+    """Async function 'update_azure_instance_events' test cases."""
+
+    def setUp(self):
+        """Set up variables for the tests."""
+        self.accounts = [
+            account_helper.generate_cloud_account(
+                cloud_type=AZURE_PROVIDER_STRING,
+                azure_subscription_id=_faker.uuid4(),
+                is_enabled=True,
+            ),
+            account_helper.generate_cloud_account(
+                cloud_type=AZURE_PROVIDER_STRING,
+                azure_subscription_id=_faker.uuid4(),
+                is_enabled=False,
+            ),
+        ]
+
+    @patch("api.clouds.azure.tasks.update_azure_instance_events_for_account.delay")
+    def test_update_azure_instance_events(
+        self,
+        mock_update_azure_instance_events_for_account,
+    ):
+        """Test functionality of update azure instance events for all accounts."""
+        update_azure_instance_events()
+
+        expected_calls = [call(account.cloud_account_id) for account in self.accounts]
+        mock_update_azure_instance_events_for_account.assert_has_calls(expected_calls)
+
+    def test_update_azure_instance_events_for_account_dne(self):
+        """Test that a log returns when the cloud account does not exist."""
+        account_id = _faker.uuid4()
+
+        with self.assertLogs(log_prefix, level="INFO") as logging_watcher:
+            update_azure_instance_events_for_account(account_id)
+            self.assertIn(
+                f"Azure Cloud Account {account_id} not found; "
+                "skipping instance events update",
+                logging_watcher.output[0],
+            )
+
+    @patch("api.clouds.azure.tasks.onboarding.create_initial_azure_instance_events")
+    @patch("api.clouds.azure.tasks.onboarding.get_vms_for_subscription")
+    def test_update_azure_instance_events_for_account(
+        self,
+        mock_get_vms,
+        mock_create_initial_azure_instance_events,
+    ):
+        """Test typical behavior for 'update_azure_instance_events_for_account'."""
+        account = self.accounts[0]
+        vms = account_helper.generate_azure_vm(account.cloud_account_id)
+        mock_get_vms.return_value = vms
+
+        update_azure_instance_events_for_account(account.cloud_account_id)
+        mock_create_initial_azure_instance_events.assert_called_with(
+            account.content_object, vms
+        )

--- a/cloudigrade/api/tests/clouds/azure/util/test_create_initial_azure_instance_events.py
+++ b/cloudigrade/api/tests/clouds/azure/util/test_create_initial_azure_instance_events.py
@@ -36,8 +36,12 @@ class CreateInitialAzureInstanceEvents(TestCase):
         self.assertTrue(AzureInstance.objects.count() == 2)
         self.assertTrue(AzureInstance.objects.filter(resource_id=vm1["id"]).exists())
         self.assertTrue(AzureInstance.objects.filter(resource_id=vm2["id"]).exists())
-        self.assertTrue(AzureInstanceEvent.objects.count() == 1)
-        self.assertTrue(InstanceEvent.objects.count() == 1)
+        self.assertTrue(AzureInstanceEvent.objects.count() == 2)
+        self.assertTrue(InstanceEvent.objects.count() == 2)
+        # Both VMs have associated InstanceEvents created
         self.assertEqual(
-            InstanceEvent.objects.first().event_type, InstanceEvent.TYPE.power_on
+            InstanceEvent.objects.first().event_type, InstanceEvent.TYPE.power_off
+        )
+        self.assertEqual(
+            InstanceEvent.objects.last().event_type, InstanceEvent.TYPE.power_on
         )

--- a/cloudigrade/api/tests/helper.py
+++ b/cloudigrade/api/tests/helper.py
@@ -1373,3 +1373,51 @@ class ModelStrTestMixin:
         )
         for field_name in field_names:
             self.assertIn(f"{field_name}=", output)
+
+
+def generate_azure_vm(subscription_id):
+    """
+    Generate mock VM info returned from get_vms_for_subscription.
+
+    Args:
+        subscription_id (uuid): The UUID of the subscription.
+
+    Returns:
+        List. List containing the vm info object.
+    """
+    rg_name = _faker.slug()
+    resource_id = (
+        f"/subscriptions/{subscription_id}/resourceGroups/"
+        f"{rg_name}/providers/Microsoft.Compute/virtualMachines/{_faker.name()}"
+    )
+    vm_info = [
+        {
+            "id": resource_id,
+            "vm_id": f"{_faker.uuid4()}",
+            "name": f"{rg_name}",
+            "type": "Microsoft.Compute/virtualMachines",
+            "image_sku": "82gen2",
+            "region": "eastus",
+            "azure_marketplace_image": False,
+            "resourceGroup": f"{rg_name}",
+            "running": False,
+            "is_encrypted": False,
+            "architecture": "x64",
+            "vm_size": "Standard_B1s",
+            "inspection_json": {
+                "image_reference": {
+                    "additional_properties": {},
+                    "id": None,
+                    "publisher": "RedHat",
+                    "offer": "RHEL",
+                    "sku": "82gen2",
+                    "version": "latest",
+                    "exact_version": "8.2.2022031402",
+                    "shared_gallery_image_id": None,
+                    "community_gallery_image_id": None,
+                }
+            },
+        }
+    ]
+
+    return vm_info

--- a/cloudigrade/config/celery.py
+++ b/cloudigrade/config/celery.py
@@ -92,6 +92,13 @@ app.conf.beat_schedule = {
             default=60 * 60 * 24 * 7,  # 1 week in seconds
         ),
     },
+    "update_azure_instance_events_every_hour": {
+        "task": "api.clouds.azure.tasks.update_azure_instance_events",
+        "schedule": env.int(
+            "UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE",
+            default=60 * 60,  # hourly
+        ),
+    },
     # Disabled Tasks
     # Important note for future readers! If you intend to disable an existing task,
     # you need to either 1) keep it here and reconfigure with '"schedule": 999999' and

--- a/cloudigrade/config/settings/base.py
+++ b/cloudigrade/config/settings/base.py
@@ -553,6 +553,12 @@ CELERY_TASK_ROUTES = {
     "api.clouds.azure.tasks.check_azure_subscription_and_create_cloud_account": {
         "queue": "check_azure_subscription_and_create_cloud_account"
     },
+    "api.clouds.azure.tasks.update_azure_instance_events": {
+        "queue": "update_azure_instance_events"
+    },
+    "api.clouds.azure.tasks.update_azure_instance_events_for_account": {
+        "queue": "update_azure_instance_events_for_account"
+    },
 }
 
 #####################################################################

--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -596,6 +596,8 @@ objects:
           value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
+        - name: UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE
+          value: ${UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE}
     - name: listener
       #
       # Component cloudigrade-listener deployment:
@@ -1147,6 +1149,8 @@ objects:
           value: ${CHECK_AND_CACHE_SQS_QUEUES_LENGTHS_SCHEDULE}
         - name: ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API
           value: ${ENABLE_SYNTHETIC_DATA_REQUEST_HTTP_API}
+        - name: UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE
+          value: ${UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE}
 # Secrets
 - apiVersion: v1
   data:
@@ -1513,6 +1517,8 @@ parameters:
     synthesize_instances,\
     synthesize_runs_and_usage,\
     synthesize_user,\
+    update_azure_instance_events,\
+    update_azure_instance_events_for_account,\
     update_from_sources_kafka_message,\
     unpause_from_sources_kafka_message"
 - name: CELERY_TARGET_AVERAGE_CPU_UTILIZATION
@@ -1863,3 +1869,7 @@ parameters:
   displayName: Enable the synthetic data internal HTTP API
   required: true
   value: 'false'
+- name: UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE
+  displayName: Update Azure instance events schedule (hourly)
+  required: true
+  value: '3600'


### PR DESCRIPTION
# Description

Cloudigrade should know about instances starting/stopping after it has already been defined by sources. This should get the list of instances that cloudigrade already knows about and adds "power on" and "power off" events to our DB.

# Solution
- I added a celery task that defaults to running hourly for updating all of the Azure instances.
- Modified the `create_initial_azure_instance_events` function to call `save_instance_events` even when the VMs are not running so you always get the initial event
- Modified the `save_instance_events` function to create InstanceEvents for both `power_on` and `power_off` based on if the VM is running or not

To Do:

- [x] Linting
- [x] Testing (adding test coverage)

# Testing

## Setup
I've set up my environment locally to test, following the instructions here: https://github.com/cloudigrade/cloudigrade/wiki/How-do-I-run-Sources-&-Kafka-locally-for-development. You will also need to have redis, and postgres running locally, and the various celery related commands.

All in all, you'll need terminal windows open with the following:
- cloudigrade `runserver`
- cloudigrade: `./manage.py listen_to_sources`
- cloudigrade: `celery --app cloudigrade.config worker --loglevel info --pool solo --without-gossip --without-mingle --concurrency 1 --task-events --queues $CELERY_QUEUE_NAMES`
- cloudigrade: `UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE=30 celery --app cloudigrade.config beat --loglevel info --scheduler django_celery_beat.schedulers:DatabaseScheduler`
- sources (from wiki)
- kafka & zookeeper (from wiki)

**NOTES**
The task by default runs every hour, however, I've added the `UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE=30` to run more frequently when calling the related celery commands to so you can see it actually happening sooner. Feel free to update that time to whatever you like.

`CELERY_QUEUE_NAMES` is taken from the code, it's the list of celery Q's we have running, you can grab it from the yaml file or settings file.

If testing locally (ie not using pods), you may want to set the `KAFKA_LISTENER_ADDRESS_FAMILY=v4` in your environment variables.

## Running
- create an Azure Source: https://github.com/cloudigrade/cloudigrade/wiki/How-do-I-run-Sources-&-Kafka-locally-for-development#creating-a-source-and-application  
- If tracking the terminal window with the celery tasks, you should see the VM/VMSS instances being successfully loaded into `cloudigrade`
- Depending on the time value you set, you should start also seeing the following log and the VM/VMSS instances being updated (should not create additional InstanceEvents since their state has not changed yet): 
```
2022-10-18 10:44:50,532 | INFO | 54561 | strategy.py:task_message_handler:161 | requestid:None | Task api.clouds.azure.tasks.update_azure_instance_events[167c7dc5-adf0-435e-8c81-f67ebaf707b4] received
```
- In Portal (Azure), start a stopped machine or stop a running machine.
- After your specified time period, you should see the update task run and a new InstanceEvent created in the DB for that instance that matches either `power_on` or `power off` depending on what happened.

# Notes/Questions
- At the time, I have not made any changes to tests, I will update once that has been completed
- I was curious if instead of running it in a for loop for each cloud account, that I should run things asynchronously? Right now, because we're testing with 1 account, it's not a huge necessity, but as we have people using the service and adding more accounts, I think this will be important. Thoughts?
  - Async has been added
