### PR TITLE
don't let codeql install and analyze python dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,9 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: python
+        # Override the default behavior so that the action doesn't attempt
+        # to auto-install Python dependencies
+        setup-python-dependencies: false
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
This PR tells CodeQL _not_ to install our project's Python dependencies (auto-detected poetry). We aren't scanning our dependencies anyway. So, installing them just wastes time both in the install process and in the "Perform CodeQL Analysis" step (which spends many minutes "extracting" them only to _ignore_ them later in the analysis).

- This PR's CodeQL run time: `4m48s`
- Other recent CodeQL run times: `14m59s`, `17m39s`, `14m54s`

See also [all recent action runs](https://github.com/cloudigrade/cloudigrade/actions/workflows/codeql-analysis.yml).

For https://github.com/cloudigrade/cloudigrade/issues/1138 followup to initial PR https://github.com/cloudigrade/cloudigrade/pull/1311