### PR TITLE
autoretry initial_azure_vm_discovery if ClientAuthenticationError is raised

### DIFF
--- a/cloudigrade/api/clouds/azure/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/azure/tasks/onboarding.py
@@ -142,9 +142,6 @@ def initial_azure_vm_discovery(azure_cloud_account_id):
         )
         return
 
-    account_subscription_id = azure_cloud_account.subscription_id
-    vms_data = get_vms_for_subscription(account_subscription_id)
-
     try:
         user_id = cloud_account.user.id
     except User.DoesNotExist:
@@ -156,6 +153,9 @@ def initial_azure_vm_discovery(azure_cloud_account_id):
             azure_cloud_account_id,
         )
         return
+
+    account_subscription_id = azure_cloud_account.subscription_id
+    vms_data = get_vms_for_subscription(account_subscription_id)
 
     # Lock the task at a user level. A user can only run one task at a time.
     with lock_task_for_user_ids([user_id]):

--- a/cloudigrade/api/clouds/azure/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/azure/tasks/onboarding.py
@@ -1,6 +1,7 @@
 """Celery tasks related to on-boarding new customer Azure cloud accounts."""
 import logging
 
+from azure.core.exceptions import ClientAuthenticationError
 from django.conf import settings
 from django.utils.translation import gettext as _
 from rest_framework.serializers import ValidationError
@@ -106,7 +107,10 @@ def check_azure_subscription_and_create_cloud_account(
     )
 
 
-@retriable_shared_task(name="api.clouds.azure.tasks.initial_azure_vm_discovery")
+@retriable_shared_task(
+    name="api.clouds.azure.tasks.initial_azure_vm_discovery",
+    autoretry_for=(ClientAuthenticationError,),
+)
 def initial_azure_vm_discovery(azure_cloud_account_id):
     """
     Fetch and save instances data found upon enabling an AzureCloudAccount.

--- a/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_initial_azure_vm_discovery.py
+++ b/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_initial_azure_vm_discovery.py
@@ -1,5 +1,5 @@
 """Collection of tests for azure.tasks.onboarding.initial_azure_vm_discovery."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import faker
 from django.test import TestCase
@@ -19,6 +19,24 @@ log_prefix = "api.clouds.azure.tasks.onboarding"
 class InitialAzureVmDiscovery(TestCase):
     """Celery task 'initial_azure_vm_discovery' test cases."""
 
+    def setUp(self):
+        """Set up common variables for tests."""
+        compute_client_patch = patch("util.azure.vm.ComputeManagementClient")
+        self.mock_compute_client = compute_client_patch.start()
+        self.addCleanup(compute_client_patch.stop)
+
+    def assertVirtualMachinesListAllCalls(self, number_of_accounts=1):
+        """Assert that virtual_machines.list_all was called as expected."""
+        expected_list_all_calls = [
+            _call
+            for _call in [call(), call(params={"statusOnly": "true"})]
+            for _ in range(number_of_accounts)
+        ]
+        returned_client = self.mock_compute_client.return_value
+        returned_client.virtual_machines.list_all.assert_has_calls(
+            expected_list_all_calls
+        )
+
     def test_initial_azure_vm_discovery(self):
         """Test happy path of initial_azure_vm_discovery."""
         subscription_id = _faker.uuid4()
@@ -37,6 +55,9 @@ class InitialAzureVmDiscovery(TestCase):
                 logging_watcher.output[0],
             )
 
+        self.mock_compute_client.assert_called()
+        self.assertVirtualMachinesListAllCalls()
+
     def test_initial_azure_vm_discovery_account_does_not_exist(self):
         """Test behavior of initial_azure_vm_discovery with non-existent account."""
         account_id = _faker.pyint()
@@ -48,6 +69,8 @@ class InitialAzureVmDiscovery(TestCase):
                 " could not be found for initial vm discovery",
                 logging_watcher.output[0],
             )
+
+        self.mock_compute_client.assert_not_called()
 
     def test_initial_azure_vm_discovery_account_disabled(self):
         """Test behavior of initial_azure_vm_discovery with disabled account."""
@@ -63,6 +86,8 @@ class InitialAzureVmDiscovery(TestCase):
                 logging_watcher.output[0],
             )
 
+        self.mock_compute_client.assert_not_called()
+
     def test_initial_azure_vm_discovery_account_paused(self):
         """Test behavior of initial_azure_vm_discovery with paused account."""
         account = account_helper.generate_cloud_account(
@@ -76,6 +101,8 @@ class InitialAzureVmDiscovery(TestCase):
                 " skipping initial vm discovery",
                 logging_watcher.output[0],
             )
+
+        self.mock_compute_client.assert_not_called()
 
     @patch("api.clouds.azure.tasks.onboarding.lock_task_for_user_ids")
     @patch("api.clouds.azure.tasks.onboarding.AzureCloudAccount.objects.get")
@@ -111,3 +138,9 @@ class InitialAzureVmDiscovery(TestCase):
             "skipping initial vm discovery.",
             logging_watcher.output[0],
         )
+
+        # This is somewhat expected, but we ask Azure for the VMs *before* we check
+        # that the account was deleted. Why? Because the account may have been deleted
+        # during the time we were asking Azure for the VMs.
+        self.mock_compute_client.assert_called()
+        self.assertVirtualMachinesListAllCalls()

--- a/cloudigrade/util/azure/vm.py
+++ b/cloudigrade/util/azure/vm.py
@@ -48,15 +48,15 @@ def get_vms_for_subscription(azure_subscription_id):
                 vms.append(vm_info(cm_client, image_properties, discovered_vm))
 
         return vms
-    except ClientAuthenticationError:
-        logger.error(
+    except ClientAuthenticationError as e:
+        logger.exception(
             _(
                 "Could not discover vms for subscription %(subscription_id)s, "
-                "Failed to authenticate a new client."
+                "Failed to authenticate a new client. %(exception)s"
             ),
-            {"subscription_id": azure_subscription_id},
+            {"subscription_id": azure_subscription_id, "exception": e},
         )
-        return []
+        raise e
 
 
 def vm_info(cm_client, image_properties, discovered_vm, vm_with_status=None):


### PR DESCRIPTION
This _might_ help with some of QE's tests that are showing no instances after creating an Azure source. See thread here in Slack: https://ansible.slack.com/archives/C8VGAPJNN/p1667240023629059?thread_ts=1667222434.071519&cid=C8VGAPJNN

We call `initial_azure_vm_discovery` once from `AzureCloudAccount.enable`. Previously, if we couldn't reach the customer's subscription upon trying to list VMs in that function, the function suppressed the exception and returned an empty list. I suspect that if we just use our standard backoff-and-retry logic, we may eventually gain the access we think we should have.

This may also help with https://github.com/cloudigrade/cloudigrade/issues/1375