### PR TITLE
Handle aborting deletion errors

### DIFF
--- a/cloudigrade/api/tasks/sources.py
+++ b/cloudigrade/api/tasks/sources.py
@@ -202,15 +202,17 @@ def delete_from_sources_kafka_message(message, headers):
     logger.info(
         _(
             "delete_from_sources_kafka_message for account_number %(account_number)s, "
+            "org_id %(org_id)s, "
             "platform_id %(platform_id)s"
         ),
         {
             "account_number": account_number,
+            "org_id": org_id,
             "platform_id": platform_id,
         },
     )
 
-    if account_number is None or platform_id is None:
+    if (not account_number and not org_id) or platform_id is None:
         logger.error(_("Aborting deletion. Incorrect message details."))
         return
 

--- a/cloudigrade/api/tests/tasks/sources/test_delete_from_sources_kafka_message.py
+++ b/cloudigrade/api/tests/tasks/sources/test_delete_from_sources_kafka_message.py
@@ -40,6 +40,7 @@ class DeleteFromSourcesKafkaMessageTest(TestCase):
         self.assertEqual(aws_models.AwsCloudAccount.objects.count(), 1)
 
         account_number = str(self.user.account_number)
+        org_id = None
         (
             message,
             headers,
@@ -52,8 +53,9 @@ class DeleteFromSourcesKafkaMessageTest(TestCase):
 
         expected_logger_infos = [
             "INFO:api.tasks.sources:delete_from_sources_kafka_message "
-            "for account_number "
-            f"{account_number}, platform_id {self.application_authentication_id}",
+            f"for account_number {account_number}, "
+            f"org_id {org_id}, "
+            f"platform_id {self.application_authentication_id}",
             "INFO:api.tasks.sources:Deleting CloudAccounts using filter "
             f"(AND: ('platform_application_id', {self.application_id}), "
             f"('platform_authentication_id', {self.authentication_id}))",


### PR DESCRIPTION

Fix for:

```
Aborting deletion: Incorrect message details
```

- Handle source delete Kafka messages where the account_number is not specified and only the org_id is provided.

Fix for: https://github.com/cloudigrade/cloudigrade/issues/1299

