### PR TITLE
Adding support for /internal/clear_cache

### DIFF
--- a/cloudigrade/internal/tests/views/test_clear_cache.py
+++ b/cloudigrade/internal/tests/views/test_clear_cache.py
@@ -1,0 +1,37 @@
+"""Collection of tests for Clearing Internal cache."""
+import faker
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from internal.views import clear_cache
+
+_faker = faker.Faker()
+
+
+class ClearCacheTest(TestCase):
+    """Clear cache view test case."""
+
+    def setUp(self):
+        """Set up a bunch shared test data."""
+        self.factory = APIRequestFactory()
+
+    def test_clear_cache(self):
+        """Test happy path success for clearing the cache."""
+        key1, val1 = _faker.word(), _faker.slug()
+        key2, val2 = _faker.word(), _faker.slug()
+
+        cache.set(key1, val1)
+        cache.set(key2, val2)
+
+        self.assertEqual(cache.get(key1), val1)
+        self.assertEqual(cache.get(key2), val2)
+
+        request = self.factory.post("/clear_cache")
+
+        response = clear_cache(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.data)
+
+        self.assertEqual(cache.get(key1), None)
+        self.assertEqual(cache.get(key2), None)

--- a/cloudigrade/internal/urls.py
+++ b/cloudigrade/internal/urls.py
@@ -107,6 +107,7 @@ urlpatterns += [
 # URL patterns for potentially-destructive custom commands.
 urlpatterns += [
     path("cache/<str:key>/", views.cache_keys, name="internal-cache"),
+    path("clear_cache/", views.clear_cache, name="internal-clear-cache"),
     path(
         "delete_cloud_accounts_not_in_sources/",
         views.delete_cloud_accounts_not_in_sources,

--- a/cloudigrade/internal/views.py
+++ b/cloudigrade/internal/views.py
@@ -396,6 +396,17 @@ def cache_keys(request, key):
         return Response(data=None)
 
 
+@api_view(["POST"])
+@authentication_classes([IdentityHeaderAuthenticationInternal])
+@permission_classes([permissions.AllowAny])
+@schema(None)
+def clear_cache(request):
+    """Clear all cache keys."""
+    logger.info(_("Clearing all cache keys"))
+    cache.clear()
+    return Response(data=None)
+
+
 @api_view(["GET"])
 @authentication_classes([IdentityHeaderAuthenticationInternal])
 @permission_classes([permissions.AllowAny])


### PR DESCRIPTION
- Adding support for /internal/clear_cache, this triggers a cache clear for deleting all cached keys.

For: https://github.com/cloudigrade/cloudigrade/issues/1264
