### PR TITLE
add github workflow jobs to check .python-version against the actual python version provided by build-container

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,15 @@ jobs:
       - run: tox -e py39
       - run: codecov
 
+  test-python-version:
+    name: python-version
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
+    steps:
+      - uses: actions/checkout@v3
+      - run: python --version | grep '^Python '$(cat .python-version)'$'
+
   test-flake8:
     name: flake8
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,15 @@ jobs:
       - run: tox -e py39
       - run: codecov
 
+  test-python-version:
+    name: python-version
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
+    steps:
+      - uses: actions/checkout@v3
+      - run: python --version | grep '^Python '$(cat .python-version)'$'
+
   test-flake8:
     name: flake8
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds a rudimentary test to check the installed version of Python against what's defined in `.python-version`. For now, this is only effectively testing what version is installed in the test's `build-container` image, not necessarily the `cloudigrade` image itself. I may iterate on this in a future branch+PR to try to assert the latter as well, but I think this is a good enough start.