### PR TITLE
change OpenShift template apiVersion from "v1" to "template.openshift.io/v1"

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cloudigrade

--- a/deployment/stage-smoke.yaml
+++ b/deployment/stage-smoke.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: cloudigrade-smoke


### PR DESCRIPTION
…due to potential openshift client incompatibilities

See also this email: https://groups.google.com/a/redhat.com/g/hcc-tech-list/c/HwsOYsPeM6A