### PR TITLE
Migrate to the latest codecov uploader.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,12 @@ jobs:
       image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
     steps:
       - uses: actions/checkout@v3
-      - run: pip install tox codecov poetry
+      - run: pip install tox poetry
       - run: tox -e py39
-      - run: codecov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: artifacts/junit-cloudigrade.xml
 
   test-python-version:
     name: python-version
@@ -33,7 +36,7 @@ jobs:
       image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
     steps:
       - uses: actions/checkout@v3
-      - run: pip install tox codecov poetry
+      - run: pip install tox poetry
       - run: tox -e flake8
 
   test-vulnerability:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1353,7 +1353,7 @@ traitlets = "*"
 
 [package.extras]
 doc = ["ipykernel", "myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
-test = ["codecov", "coverage", "ipykernel (>=6.12)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
+test = ["coverage", "ipykernel (>=6.12)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-console"


### PR DESCRIPTION
- Migrate to the latest codecov uploader.

For: https://github.com/cloudigrade/cloudigrade/issues/1405
