### PR TITLE
ISSUE-1401 ValueError: Cannot assign "AzureCloudAccount...."

### DIFF
--- a/cloudigrade/api/clouds/azure/tasks/onboarding.py
+++ b/cloudigrade/api/clouds/azure/tasks/onboarding.py
@@ -222,7 +222,9 @@ def update_azure_instance_events_for_account(cloud_account_id):
         None: Run as an asynchronous Celery task.
     """
     try:
-        cloud_account = AzureCloudAccount.objects.get(subscription_id=cloud_account_id)
+        azure_cloud_account = AzureCloudAccount.objects.get(
+            subscription_id=cloud_account_id
+        )
     except AzureCloudAccount.DoesNotExist:
         # AzureCloudAccount could have been deleted prior to calling/running task
         logger.info(
@@ -234,5 +236,7 @@ def update_azure_instance_events_for_account(cloud_account_id):
         )
         return
 
-    vms_info = get_vms_for_subscription(cloud_account.subscription_id)
-    create_initial_azure_instance_events(cloud_account, vms_info)
+    vms_info = get_vms_for_subscription(azure_cloud_account.subscription_id)
+    create_initial_azure_instance_events(
+        azure_cloud_account.cloud_account.get(), vms_info
+    )

--- a/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_update_azure_instance_events.py
+++ b/cloudigrade/api/tests/clouds/azure/tasks/onboarding/test_update_azure_instance_events.py
@@ -70,6 +70,4 @@ class UpdateAzureInstanceEvents(TestCase):
         mock_get_vms.return_value = vms
 
         update_azure_instance_events_for_account(account.cloud_account_id)
-        mock_create_initial_azure_instance_events.assert_called_with(
-            account.content_object, vms
-        )
+        mock_create_initial_azure_instance_events.assert_called_with(account, vms)


### PR DESCRIPTION
# Description
Sentry error found:
```py
ValueError: Cannot assign "AzureCloudAccount(id=5919, subscription_id=..., created_at=parse('2022-11-14T20:57:25.972049+00:00'), updated_at=parse('2022-11-14T20:57:25.972070+00:00'))": "Instance.cloud_account" must be a "CloudAccount" instance.
(4 additional frame(s) were not displayed)
...
  File "api/clouds/azure/util.py", line 292, in save_instance
    Instance.objects.create(cloud_account=account, content_object=azure_instance)
  File "django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "django/db/models/query.py", line 451, in create
    obj = self.model(**kwargs)
  File "django/db/models/base.py", line 485, in __init__
    _setattr(self, field.name, rel_obj)
  File "django/db/models/fields/related_descriptors.py", line 215, in __set__
    raise ValueError(
```

# Solution
- Updated the call to _create_initial_azure_instance_ to use/get the generic **CloudAccount** from the **AzureCloudAccount**
- Modified the associated test to use verify the generic **CloudAccount** is being used/called

# Testing

## Setup
(LOCAL)
I've set up my environment locally to test, following the instructions here: https://github.com/cloudigrade/cloudigrade/wiki/How-do-I-run-Sources-&-Kafka-locally-for-development. You will also need to have redis, and postgres running locally, and the various celery related commands.

All in all, you'll need terminal windows open with the following:
- cloudigrade `runserver`
- cloudigrade: `./manage.py listen_to_sources`
- cloudigrade: `celery --app cloudigrade.config worker --loglevel info --pool solo --without-gossip --without-mingle --concurrency 1 --task-events --queues $CELERY_QUEUE_NAMES`
- cloudigrade: `UPDATE_AZURE_INSTANCE_EVENTS_SCHEDULE=30 celery --app cloudigrade.config beat --loglevel info --scheduler django_celery_beat.schedulers:DatabaseScheduler`
- sources (from wiki)
- kafka & zookeeper (from wiki)

(EPHEMERAL)
- Spin up the ephemeral environment and use the tag associated with this PR (INSERT HERE)

## Testing
Try the steps defined by Brad using ephemeral: [Repro Instructions](https://github.com/cloudigrade/cloudigrade/issues/1401#issuecomment-1315874571)
- Make sure the ValueError does not trigger

# Notes/Questions
N/A