### PR TITLE
run github tests workflow on pushes to master, not all pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,13 @@ name: Tests
 env:
   IMAGE_NAME: quay.io/cloudservices/cloudigrade
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   test-py39:


### PR DESCRIPTION
This simplifies our GitHub PR checks so PRs based on branches in the main repo don't get run twice for every push.

followup to [consolidate "PR" and "Push" workflows into one "Tests" workflow #1393](https://github.com/cloudigrade/cloudigrade/pull/1393)