### PR TITLE
pin last 3.x version of tox due to problems with latest 4.x releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
     steps:
       - uses: actions/checkout@v3
-      - run: pip install tox poetry
+      - run: pip install tox==3.27.1 poetry
       - run: tox -e py39
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -43,7 +43,7 @@ jobs:
       image: ghcr.io/cloudigrade/build-container:ubi-8.7-923-python-3.9.13
     steps:
       - uses: actions/checkout@v3
-      - run: pip install tox poetry
+      - run: pip install tox==3.27.1 poetry
       - run: tox -e flake8
 
   test-vulnerability:


### PR DESCRIPTION
Let's pin tox to the last 3.x release until we can figure out what's wrong with 4.x.