### PR TITLE
simplify AWS policy definition and verification

### DIFF
--- a/cloudigrade/api/clouds/aws/util.py
+++ b/cloudigrade/api/clouds/aws/util.py
@@ -25,17 +25,11 @@ def verify_permissions(customer_role_arn):  # noqa: C901
         customer_role_arn (str): ARN to access the customer's AWS account
 
     Note:
-        This function not only verifies; it also has the side effect of configuring
-        the AWS CloudTrail. This should be refactored into a more explicit operation,
-        but at the time of this writing, there is no "dry run" check for CloudTrail
-        operations. Callers should be aware of the risk that we may configure CloudTrail
-        but somewhere else rollback our transaction, leaving that Trail orphaned.
-
-        This function also has the side-effect of notifying sources and updating the
+        This function also has the side effect of notifying sources and updating the
         application status to unavailable if we cannot complete processing normally.
 
     Returns:
-        boolean indicating if the verification and CloudTrail setup succeeded.
+        boolean True if customer AWS account is appropriately accessible.
 
     """
     aws_account_id = aws.AwsArn(customer_role_arn).account_id

--- a/cloudigrade/util/aws/__init__.py
+++ b/cloudigrade/util/aws/__init__.py
@@ -6,7 +6,6 @@ from util.aws.cloudtrail import (
 )
 from util.aws.helper import (
     COMMON_AWS_ACCESS_DENIED_ERROR_CODES,
-    get_regions,
     rewrap_aws_errors,
     verify_account_access,
 )

--- a/cloudigrade/util/aws/helper.py
+++ b/cloudigrade/util/aws/helper.py
@@ -21,27 +21,6 @@ COMMON_AWS_ACCESS_DENIED_ERROR_CODES = (
 )
 
 
-def get_regions(session, service_name="ec2"):
-    """
-    Get the full list of available AWS regions for the given service.
-
-    Args:
-        session (boto3.Session): A temporary session tied to a customer account
-        service_name (str): Name of AWS service. Default is 'ec2'.
-
-    Returns:
-        list: The available AWS region names.
-
-    """
-    client = session.client(service_name)
-    available_regions = client.describe_regions()
-    region_list = []
-    for region in available_regions["Regions"]:
-        region_list.append(region["RegionName"])
-
-    return region_list
-
-
 def verify_account_access(session):
     """
     Check role for proper access to AWS APIs.

--- a/cloudigrade/util/aws/sts.py
+++ b/cloudigrade/util/aws/sts.py
@@ -10,29 +10,13 @@ from util.aws.arn import AwsArn
 
 logger = logging.getLogger(__name__)
 
-
 cloudigrade_policy = {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Sid": "CloudigradePolicy",
             "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:ModifySnapshotAttribute",
-                "ec2:DescribeSnapshotAttribute",
-                "ec2:DescribeSnapshots",
-                "ec2:CopyImage",
-                "ec2:CreateTags",
-                "ec2:DescribeRegions",
-                "cloudtrail:CreateTrail",
-                "cloudtrail:UpdateTrail",
-                "cloudtrail:PutEventSelectors",
-                "cloudtrail:DescribeTrails",
-                "cloudtrail:StartLogging",
-                "cloudtrail:DeleteTrail",
-            ],
+            "Action": ["sts:GetCallerIdentity"],
             "Resource": "*",
         }
     ],

--- a/cloudigrade/util/tests/aws/test_helper.py
+++ b/cloudigrade/util/tests/aws/test_helper.py
@@ -81,52 +81,6 @@ class UtilAwsHelperTest(TestCase):
         with self.assertRaises(AwsThrottlingException):
             dummy_adder()
 
-    def test_get_regions_with_no_args(self):
-        """Assert get_regions with no args returns expected regions."""
-        mock_region_names = [
-            f"region-{uuid.uuid4()}",
-            f"region-{uuid.uuid4()}",
-        ]
-
-        mock_regions = {
-            "Regions": [
-                {"RegionName": mock_region_names[0]},
-                {"RegionName": mock_region_names[1]},
-            ]
-        }
-
-        mock_client = Mock()
-        mock_client.describe_regions.return_value = mock_regions
-        mock_session = Mock()
-        mock_session.client.return_value = mock_client
-        actual_regions = helper.get_regions(mock_session)
-        self.assertTrue(mock_client.describe_regions.called)
-        mock_session.client.assert_called_with("ec2")
-        self.assertListEqual(mock_region_names, actual_regions)
-
-    def test_get_regions_with_custom_service(self):
-        """Assert get_regions with service name returns expected regions."""
-        mock_region_names = [
-            f"region-{uuid.uuid4()}",
-            f"region-{uuid.uuid4()}",
-        ]
-
-        mock_regions = {
-            "Regions": [
-                {"RegionName": mock_region_names[0]},
-                {"RegionName": mock_region_names[1]},
-            ]
-        }
-
-        mock_client = Mock()
-        mock_client.describe_regions.return_value = mock_regions
-        mock_session = Mock()
-        mock_session.client.return_value = mock_client
-        actual_regions = helper.get_regions(mock_session, "tng")
-        self.assertTrue(mock_client.describe_regions.called)
-        mock_session.client.assert_called_with("tng")
-        self.assertListEqual(mock_region_names, actual_regions)
-
     @patch("util.aws.helper._verify_policy_action")
     def test_verify_account_access_success(self, mock_verify_policy_action):
         """Assert that account access is verified when all actions are OK."""

--- a/docs/rest-api-examples.rst
+++ b/docs/rest-api-examples.rst
@@ -224,7 +224,7 @@ Response:
 
     HTTP/1.1 200 OK
     Allow: GET, HEAD, OPTIONS
-    Content-Length: 680
+    Content-Length: 358
     Content-Type: application/json
     Cross-Origin-Opener-Policy: same-origin
     Referrer-Policy: same-origin
@@ -239,20 +239,7 @@ Response:
                 "Statement": [
                     {
                         "Action": [
-                            "ec2:DescribeImages",
-                            "ec2:DescribeInstances",
-                            "ec2:ModifySnapshotAttribute",
-                            "ec2:DescribeSnapshotAttribute",
-                            "ec2:DescribeSnapshots",
-                            "ec2:CopyImage",
-                            "ec2:CreateTags",
-                            "ec2:DescribeRegions",
-                            "cloudtrail:CreateTrail",
-                            "cloudtrail:UpdateTrail",
-                            "cloudtrail:PutEventSelectors",
-                            "cloudtrail:DescribeTrails",
-                            "cloudtrail:StartLogging",
-                            "cloudtrail:DeleteTrail"
+                            "sts:GetCallerIdentity"
                         ],
                         "Effect": "Allow",
                         "Resource": "*",


### PR DESCRIPTION
Stop checking all the AWS actions that were previously required for EC2 inspection, CloudTrail, etc.