### PR TITLE
Revert "temporarily reduce codecov patch target to 0%"

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
         target: "80%"
     patch:
       default:
-        target: "0%"
+        target: "80%"
     changes:
       default: off
 


### PR DESCRIPTION
This reverts commit f6a4cb0a0ed65eacfc96f1d7cd5dce2d5ac0555c.

Revert "temporarily disable codecov patch status"

This reverts commit 3721d41f3a0daf4ad382f56edc50e79dcb769ab5.