### PR TITLE
Add a startupProbe to cloudigrade-beat

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -292,6 +292,14 @@ objects:
             --loglevel info
             --pidfile=
             --scheduler django_celery_beat.schedulers:DatabaseScheduler
+        startupProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - '[[ $(pgrep -a celery | grep -c beat) -eq 1 ]]'
+          failureThreshold: 6
+          periodSeconds: 10
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
The beat container was repeatedly restarting when the `livenessProbe` killed the container due to the app not completing its boot quick enough. To give the pod more time to boot up we'll add a `startupProbe` so the container has 60s to complete it's boot.

During troubleshooting in addition to the `livenessProbe` getting an `initialDelaySeconds: 60s` to recover, the resources for cpu and memory were increases from 100m to 200m and 128Mi to 256Mi respectively. We're going to leave resources at their original value but we may need to increase them in a follow-up pull request.