### PR TITLE
Reserve a namespace with specifying the pool name

### DIFF
--- a/deployment/scripts/pr_check.sh
+++ b/deployment/scripts/pr_check.sh
@@ -21,7 +21,7 @@ source $CICD_ROOT/build.sh
 
 # Deploy cloudigrade to an ephemeral namespace for testing
 source ${CICD_ROOT}/_common_deploy_logic.sh
-export NAMESPACE=$(bonfire namespace reserve --pool "real-managed-kafka")
+export NAMESPACE=$(bonfire namespace reserve)
 
 oc get secret/cloudigrade-aws -o json -n ephemeral-base | jq -r '.data' > aws-creds.json
 oc get secret/cloudigrade-azure -o json -n ephemeral-base | jq -r '.data' > azure-creds.json

--- a/poetry.lock
+++ b/poetry.lock
@@ -2123,13 +2123,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.14.0"
+version = "2.15.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
-    {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
+    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
+    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
 ]
 
 [package.extras]


### PR DESCRIPTION
Try to fix bonfire deploys by not specifying a pool name when reserving a namespace.