### PR TITLE
only security updates and disable dep dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
-  ]
+    "schedule:earlyMondays",
+    ":disableDependencyDashboard"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackagePatterns": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
This PR will:
1) Disable the dependency dashboard created by renovate.
2) It will create PRs for dependencies that have CVEs reported.